### PR TITLE
Add cargo-deny

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,48 +2,48 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   format:
     name: cargo fmt (stable)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: Format
-      run: cargo fmt -- --check
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Format
+        run: cargo fmt -- --check
 
   clippy:
     name: clippy (stable)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Cache ~/.cargo
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo
-        key: ${{ runner.os }}-clippy-dotcargo
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-clippy-cargo-build-target
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        components: clippy
-        override: true
-    - uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features
-        name: clippy results
+      - uses: actions/checkout@v1
+      - name: Cache ~/.cargo
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-clippy-dotcargo
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-clippy-cargo-build-target
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+          name: clippy results
 
   test:
     runs-on: ubuntu-latest
@@ -55,74 +55,64 @@ jobs:
           - stable
           - nightly
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust }}
-        override: true
-    - name: Cache ~/.cargo
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo
-        key: ${{ runner.os }}-test-dotcargo-${{ matrix.rust }}
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-test-build-target-${{ matrix.rust }}
-    - name: build --all-targets
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --all-targets
-    - name: test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Cache ~/.cargo
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-test-dotcargo-${{ matrix.rust }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-test-build-target-${{ matrix.rust }}
+      - name: build --all-targets
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-targets
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - name: Cache ~/.cargo
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo
-        key: ${{ runner.os }}-coverage-dotcargo
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-coverage-cargo-build-target
-    - uses: actions-rs/tarpaulin@v0.1
-    - name: upload coverage
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Cache ~/.cargo
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-coverage-dotcargo
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-coverage-cargo-build-target
+      - uses: actions-rs/tarpaulin@v0.1
+      - name: upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   cargo-deny:
     name: Cargo deny
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal
-    - run: |
-        set -e
-        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.8.5/cargo-deny-0.8.5-x86_64-unknown-linux-musl.tar.gz | tar xzf -
-        mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
-        echo `pwd` >> $GITHUB_PATH
-    - run: cargo deny check
-
+      - name: Checkout Rust toolcnain
+        uses: actions/checkout@v2
+        with:
+          toolchain: stable
+          override: true
+      - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -106,3 +106,23 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
+  cargo-deny:
+    name: Cargo deny
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+    - run: |
+        set -e
+        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.8.5/cargo-deny-0.8.5-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+        mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
+        echo `pwd` >> $GITHUB_PATH
+    - run: cargo deny check
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,24 +19,24 @@ readme = "README.md"
 travis-ci = { repository = "warner/magic-wormhole.rs" }
 
 [dependencies]
-serde = { version = "1.0", features = ["rc"] }
-serde_json = "1.0"
-serde_derive = "1.0"
-xsalsa20poly1305 = "0.6"
+serde = { version = "1.0.120", features = ["rc"] }
+serde_json = "1.0.61"
+serde_derive = "1.0.120"
+xsalsa20poly1305 = "0.6.0"
 spake2 = "0.2.0"
 sha2 = "0.9.2"
 hkdf = "0.10.0"
-hex = "0.4"
-rand = "0.8.1"
+hex = "0.4.2"
+rand = "0.8.2"
 regex = "1.4.3"
-log = "0.4"
-zeroize = { version = "1.2", features = ["zeroize_derive"] }
+log = "0.4.13"
+zeroize = { version = "1.2.0", features = ["zeroize_derive"] }
 sodiumoxide = "0.2.6"
-pnet = "0.27.0"
+pnet = "0.27.2"
 byteorder = "1.4.2"
-anyhow = "1.0.37"
-futures = { version = "0.3.9" }
-async-std = { version = "1.8.0", features = ["attributes"] }
+anyhow = "1.0.38"
+futures = "0.3.12"
+async-std = { version = "1.9.0", features = ["attributes"] }
 async-tungstenite = { version = "0.12.0", features = ["async-std-runtime"] }
 pin-project = "1.0.4"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 targets = []
 
 [advisories]
-db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 vulnerability = "deny"
 unmaintained = "warn"
@@ -11,10 +10,10 @@ ignore = ["RUSTSEC-2018-0015"]
 
 [licenses]
 unlicensed = "deny"
-allow = ["MIT", "Apache-2.0", "ISC", "BSD-2-Clause", "BSD-3-Clause", "MPL-2.0"]
+allow = ["BSD-2-Clause", "MPL-2.0"]
 deny = []
 copyleft = "deny"
-allow-osi-fsf-free = "neither"
+allow-osi-fsf-free = "both"
 default = "deny"
 confidence-threshold = 0.8
 exceptions = []
@@ -24,7 +23,7 @@ ignore = false
 registries = []
 
 [bans]
-multiple-versions = "deny"
+multiple-versions = "warn"
 wildcards = "allow"
 highlight = "all"
 allow = []

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,63 @@
+targets = []
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+ignore = ["RUSTSEC-2018-0015"]
+
+[licenses]
+unlicensed = "deny"
+allow = ["MIT", "Apache-2.0", "ISC", "BSD-2-Clause", "BSD-3-Clause", "MPL-2.0"]
+deny = []
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 0.8
+exceptions = []
+
+[licenses.private]
+ignore = false
+registries = []
+
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+highlight = "all"
+allow = []
+deny = []
+skip = [
+    { name = "winapi", version = "=0.2.8" },
+    { name = "unicode-xid", version = "=0.0.3" },
+    { name = "subtle", version = "=1.0.0" },
+    { name = "sha2", version = "=0.8.2" },
+    { name = "rand_hc", version = "=0.1.0" },
+    { name = "rand_core", version = "=0.3.1" },
+    { name = "rand_core", version = "=0.4.2" },
+    { name = "rand_core", version = "=0.5.1" },
+    { name = "rand_chacha", version = "=0.3.0" },
+    { name = "rand", version = "0.6.5" },
+    { name = "opaque-debug", version = "=0.2.3" },
+    { name = "log", version = "=0.3.9" },
+    { name = "autocfg", version = "=0.1.7" },
+    { name = "bitflags", version = "=0.5.0" },
+    { name = "block-buffer", version = "=0.7.3" },
+    { name = "cfg-if", version = "=0.1.10" },
+    { name = "cpuid-bool", version = "=0.1.2" },
+    { name = "crypto-mac", version = "=0.7.0" },
+    { name = "digest", version = "=0.8.1" },
+    { name = "generic-array", version = "=0.12.3" },
+    { name = "hex", version = "=0.3.2" },
+    { name = "hkdf", version = "=0.7.1" },
+    { name = "hmac", version = "=0.7.1" },
+]
+skip-tree = []
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -14,7 +14,6 @@
 //! "leader" side and one "follower" side (formerly called "sender" and "receiver").
 
 use crate::{Key, KeyPurpose};
-use futures::{task::Poll, Future};
 use serde_derive::{Deserialize, Serialize};
 
 use anyhow::{ensure, format_err, Context, Error, Result};


### PR DESCRIPTION
Fixes #99 

Allowed licenses are MIT, Apache-2.0, ISC, BSD-2-Clause, BSD-3-Clause, and MPL.
RUSTSEC-2018-0015 is allowed for now