### PR TITLE
Adds progress reporting to transfers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,14 @@ pin-project = "1.0.4"
 # for "bin" feature
 clap = { version = "2.33.3", optional = true }
 env_logger = { version = "0.8.2", optional = true }
+pbr = { version = "1.0.4", optional = true }
 
 # for some tests
 [dev-dependencies]
 env_logger = "0.8.2"
 
 [features]
-bin = ["clap", "env_logger"]
+bin = ["clap", "env_logger", "pbr"]
 # TODO remove this one day
 # - Removing it now requires all cargo calls to have --features=bin which is annoying
 # - There is a cargo issue that would allow proper bin dependencies and thus would resolve it

--- a/examples/test-file-rust2rust.rs
+++ b/examples/test-file-rust2rust.rs
@@ -61,7 +61,11 @@ async fn receive(code_rx: mpsc::Receiver<String>) {
     .await
     .unwrap();
 
-    req.accept(false).await.unwrap();
+    req.accept(false, |received, total| {
+        info!("Received {} of {}", received, total);
+    })
+    .await
+    .unwrap();
 }
 
 async fn send(code_tx: mpsc::Sender<String>) {
@@ -86,6 +90,9 @@ async fn send(code_tx: mpsc::Sender<String>) {
         &magic_wormhole::transit::DEFAULT_RELAY_SERVER
             .parse()
             .unwrap(),
+        |sent, total| {
+            info!("Sent {} of {}", sent, total);
+        },
     )
     .await
     .unwrap();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,6 +4,7 @@ use clap::{
 use log::*;
 use magic_wormhole::{transfer, CodeProvider, Wormhole};
 use std::{path::Path, str};
+use pbr::{ProgressBar, Units};
 
 #[async_std::main]
 async fn main() -> anyhow::Result<()> {
@@ -152,10 +153,16 @@ async fn main() -> anyhow::Result<()> {
         info!("wormhole receive {}\n", &welcome.code);
         let mut wormhole = connector.connect_to_client().await?;
         info!("Got key: {}", wormhole.key);
+
+        let mut pb = ProgressBar::new(0);
+        pb.format("╢▌▌░╟");
+        pb.set_units(Units::Bytes);
+
         let file = matches.value_of("file").unwrap();
-        transfer::send_file(&mut wormhole, file, &relay_server.parse().unwrap())
-            .await
-            .unwrap();
+        transfer::send_file(&mut wormhole, file, &relay_server.parse().unwrap(), move |sent, total| match sent {
+            0 => { pb.total = total; },
+            progress => { pb.set(progress); }
+        }).await.unwrap();
     } else if let Some(matches) = matches.subcommand_matches("send-many") {
         let relay_server = matches
             .value_of("relay-server")
@@ -256,11 +263,14 @@ async fn send_many(
             .await?;
             let mut wormhole = connector.connect_to_client().await?;
             let result =
-                transfer::send_file(&mut wormhole, &filename, &relay_server.parse().unwrap()).await;
+                transfer::send_file(&mut wormhole, &filename, &relay_server.parse().unwrap(), |sent, total| {
+                    // @TODO: Not sure what kind of experience is best here.
+                    info!("Sent {} of {} bytes", sent, total);
+                }).await;
             result
         } {
             Ok(_) => {
-                info!("TOOD success message");
+                info!("TODO success message");
             },
             Err(e) => {
                 warn!("Send failed, {}", e);
@@ -308,7 +318,13 @@ async fn receive(mut w: Wormhole, relay_server: &str) -> anyhow::Result<()> {
     };
 
     if answer {
-        req.accept().await
+        let mut pb = ProgressBar::new(req.filesize);
+        pb.format("╢▌▌░╟");
+        pb.set_units(Units::Bytes);
+
+        req.accept(move |received, _total| {
+            pb.set(received);
+        }).await
     } else {
         req.reject().await
     }

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -50,8 +50,9 @@ pub async fn test_file_rust2rust() -> anyhow::Result<()> {
                     .unwrap(),
                 |sent, total| {
                     log::info!("Sent {} of {} bytes", sent, total);
-                })
-                .await
+                },
+            )
+            .await
         })?;
     let receiver_task = async_std::task::Builder::new()
         .name("receiver".to_owned())
@@ -80,7 +81,8 @@ pub async fn test_file_rust2rust() -> anyhow::Result<()> {
 
             req.accept(false, |received, total| {
                 log::info!("Received {} of {} bytes", received, total);
-            }).await
+            })
+            .await
         })?;
     sender_task.await?;
     receiver_task.await?;

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -48,8 +48,10 @@ pub async fn test_file_rust2rust() -> anyhow::Result<()> {
                 &magic_wormhole::transit::DEFAULT_RELAY_SERVER
                     .parse()
                     .unwrap(),
-            )
-            .await
+                |sent, total| {
+                    log::info!("Sent {} of {} bytes", sent, total);
+                })
+                .await
         })?;
     let receiver_task = async_std::task::Builder::new()
         .name("receiver".to_owned())
@@ -76,7 +78,9 @@ pub async fn test_file_rust2rust() -> anyhow::Result<()> {
             )
             .await?;
 
-            req.accept().await
+            req.accept(|received, total| {
+                log::info!("Received {} of {} bytes", received, total);
+            }).await
         })?;
     sender_task.await?;
     receiver_task.await?;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -149,11 +149,15 @@ pub enum AnswerType {
 }
 
 /// Send a file to the other side
-pub async fn send_file(
+pub async fn send_file<F>(
     wormhole: &mut Wormhole,
     filepath: impl AsRef<Path>,
     relay_url: &RelayUrl,
-) -> Result<()> {
+    progress_handler: F
+) -> Result<()>
+where
+    F: FnMut(u64, u64) + 'static
+{
     let filename = filepath
         .as_ref()
         .file_name()
@@ -220,7 +224,7 @@ pub async fn send_file(
         .await?;
     debug!("Beginning file transfer");
 
-    tcp_file_send(&mut transit, &filepath)
+    tcp_file_send(&mut transit, &filepath, progress_handler)
         .await
         .context("Could not send file")
 }
@@ -305,7 +309,10 @@ impl<'a> ReceiveRequest<'a> {
      *
      * This will transfer the file and save it on disk.
      */
-    pub async fn accept(self) -> Result<()> {
+    pub async fn accept<F>(self, progress_handler: F) -> Result<()>
+    where
+        F: FnMut(u64, u64) + 'static
+    {
         // send file ack.
         debug!("Sending ack");
         self.wormhole
@@ -328,7 +335,7 @@ impl<'a> ReceiveRequest<'a> {
 
         debug!("Beginning file transfer");
         // TODO here's the right position for applying the output directory and to check for malicious (relative) file paths
-        tcp_file_receive(&mut transit, &self.filename, self.filesize)
+        tcp_file_receive(&mut transit, &self.filename, self.filesize, progress_handler)
             .await
             .context("Could not receive file")
     }
@@ -356,7 +363,14 @@ impl<'a> ReceiveRequest<'a> {
 
 // encrypt and send the file to tcp stream and return the sha256 sum
 // of the file before encryption.
-async fn send_records(filepath: impl AsRef<Path>, transit: &mut Transit) -> Result<Vec<u8>> {
+async fn send_records<F>(
+    filepath: impl AsRef<Path>,
+    transit: &mut Transit,
+    mut progress_handler: F
+) -> Result<Vec<u8>>
+where
+    F: FnMut(u64, u64) + 'static
+{
     // rough plan:
     // 1. Open the file
     // 2. read a block of N bytes
@@ -369,19 +383,26 @@ async fn send_records(filepath: impl AsRef<Path>, transit: &mut Transit) -> Resu
     let mut file = File::open(&filepath.as_ref())
         .await
         .context(format!("Could not open {}", &filepath.as_ref().display()))?;
-    debug!("Sending file size {}", file.metadata().await?.len());
+    //debug!("Sending file size {}", file.metadata().await?.len());
+    let file_size = file.metadata().await?.len();
+
+    // Report at 0 to allow clients to configure as necessary.
+    progress_handler(0, file_size);
 
     let mut hasher = Sha256::default();
 
     // Yeah, maybe don't allocate 4kiB on the stack…
     let mut plaintext = Box::new([0u8; 4096]);
+    let mut sent_size = 0;
     loop {
         // read a block of 4096 bytes
         let n = file.read(&mut plaintext[..]).await?;
-        debug!("sending {} bytes", n);
 
         // send the encrypted record
         transit.send_record(&plaintext[0..n]).await?;
+        sent_size += n as u64;
+        debug!("sent {} bytes out of {} bytes", sent_size, file_size);
+        progress_handler(sent_size, file_size);
 
         // sha256 of the input
         hasher.update(&plaintext[..n]);
@@ -390,17 +411,27 @@ async fn send_records(filepath: impl AsRef<Path>, transit: &mut Transit) -> Resu
             break;
         }
     }
+
     Ok(hasher.finalize_fixed().to_vec())
 }
 
-async fn receive_records(
+async fn receive_records<F>(
     filepath: impl AsRef<Path>,
     filesize: u64,
     transit: &mut Transit,
-) -> Result<Vec<u8>> {
+    mut progress_handler: F
+) -> Result<Vec<u8>>
+where
+    F: FnMut(u64, u64) + 'static
+{
     let mut hasher = Sha256::default();
     let mut f = File::create(filepath.as_ref()).await?; // TODO overwrite flags & checks & stuff
+    let total = filesize;
     let mut remaining_size = filesize as usize;
+
+    // Might not need to do this here, since `accept()` is where they'd know the filesize
+    // already...
+    progress_handler(0, total);
 
     while remaining_size > 0 {
         // 3. decrypt the vector 'enc_packet' with the key.
@@ -412,6 +443,9 @@ async fn receive_records(
         hasher.update(&plaintext);
 
         remaining_size -= plaintext.len();
+
+        let remaining = remaining_size as u64;
+        progress_handler(total - remaining, total);
     }
 
     debug!("done");
@@ -419,9 +453,16 @@ async fn receive_records(
     Ok(hasher.finalize_fixed().to_vec())
 }
 
-async fn tcp_file_send(transit: &mut Transit, filepath: impl AsRef<Path>) -> Result<()> {
+async fn tcp_file_send<F>(
+    transit: &mut Transit,
+    filepath: impl AsRef<Path>,
+    progress_handler: F
+) -> Result<()>
+where
+    F: FnMut(u64, u64) + 'static
+{
     // 11. send the file as encrypted records.
-    let checksum = send_records(filepath, transit).await?;
+    let checksum = send_records(filepath, transit, progress_handler).await?;
 
     // 13. wait for the transit ack with sha256 sum from the peer.
     debug!("sent file. Waiting for ack");
@@ -435,15 +476,19 @@ async fn tcp_file_send(transit: &mut Transit, filepath: impl AsRef<Path>) -> Res
     Ok(())
 }
 
-async fn tcp_file_receive(
+async fn tcp_file_receive<F>(
     transit: &mut Transit,
     filepath: impl AsRef<Path>,
     filesize: u64,
-) -> Result<()> {
+    progress_handler: F
+) -> Result<()>
+where
+    F: FnMut(u64, u64) + 'static
+{
     // 5. receive encrypted records
     // now skey and rkey can be used. skey is used by the tx side, rkey is used
     // by the rx side for symmetric encryption.
-    let checksum = receive_records(filepath, filesize, transit).await?;
+    let checksum = receive_records(filepath, filesize, transit, progress_handler).await?;
 
     let sha256sum = hex::encode(checksum.as_slice());
     debug!("sha256 sum: {:?}", sha256sum);

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -154,10 +154,10 @@ pub async fn send_file<F>(
     wormhole: &mut Wormhole,
     filepath: impl AsRef<Path>,
     relay_url: &RelayUrl,
-    progress_handler: F
+    progress_handler: F,
 ) -> Result<()>
 where
-    F: FnMut(u64, u64) + 'static
+    F: FnMut(u64, u64) + 'static,
 {
     let filename = filepath
         .as_ref()
@@ -312,7 +312,7 @@ impl<'a> ReceiveRequest<'a> {
      */
     pub async fn accept<F>(self, overwrite: bool, progress_handler: F) -> Result<()>
     where
-        F: FnMut(u64, u64) + 'static
+        F: FnMut(u64, u64) + 'static,
     {
         // send file ack.
         debug!("Sending ack");
@@ -336,9 +336,15 @@ impl<'a> ReceiveRequest<'a> {
 
         debug!("Beginning file transfer");
         // TODO here's the right position for applying the output directory and to check for malicious (relative) file paths
-        tcp_file_receive(&mut transit, &self.filename, self.filesize, overwrite, progress_handler)
-            .await
-            .context("Could not receive file")
+        tcp_file_receive(
+            &mut transit,
+            &self.filename,
+            self.filesize,
+            overwrite,
+            progress_handler,
+        )
+        .await
+        .context("Could not receive file")
     }
 
     /**
@@ -367,10 +373,10 @@ impl<'a> ReceiveRequest<'a> {
 async fn send_records<F>(
     filepath: impl AsRef<Path>,
     transit: &mut Transit,
-    mut progress_handler: F
+    mut progress_handler: F,
 ) -> Result<Vec<u8>>
 where
-    F: FnMut(u64, u64) + 'static
+    F: FnMut(u64, u64) + 'static,
 {
     // rough plan:
     // 1. Open the file
@@ -421,14 +427,14 @@ async fn receive_records<F>(
     filesize: u64,
     transit: &mut Transit,
     overwrite: bool,
-    mut progress_handler: F
+    mut progress_handler: F,
 ) -> Result<Vec<u8>>
 where
-    F: FnMut(u64, u64) + 'static
+    F: FnMut(u64, u64) + 'static,
 {
     let mut hasher = Sha256::default();
     let total = filesize;
-    
+
     let mut options = OpenOptions::new();
     options.write(true);
     if overwrite {
@@ -466,10 +472,10 @@ where
 async fn tcp_file_send<F>(
     transit: &mut Transit,
     filepath: impl AsRef<Path>,
-    progress_handler: F
+    progress_handler: F,
 ) -> Result<()>
 where
-    F: FnMut(u64, u64) + 'static
+    F: FnMut(u64, u64) + 'static,
 {
     // 11. send the file as encrypted records.
     let checksum = send_records(filepath, transit, progress_handler).await?;
@@ -491,15 +497,16 @@ async fn tcp_file_receive<F>(
     filepath: impl AsRef<Path>,
     filesize: u64,
     overwrite: bool,
-    progress_handler: F
+    progress_handler: F,
 ) -> Result<()>
 where
-    F: FnMut(u64, u64) + 'static
+    F: FnMut(u64, u64) + 'static,
 {
     // 5. receive encrypted records
     // now skey and rkey can be used. skey is used by the tx side, rkey is used
     // by the rx side for symmetric encryption.
-    let checksum = receive_records(filepath, filesize, transit, overwrite, progress_handler).await?;
+    let checksum =
+        receive_records(filepath, filesize, transit, overwrite, progress_handler).await?;
 
     let sha256sum = hex::encode(checksum.as_slice());
     debug!("sha256 sum: {:?}", sha256sum);


### PR DESCRIPTION
- Sending and Receiving (the latter via `accept()`) now accept a
  callback parameter for progress reporting, in the form of an
  `FnMut(u64, u64)`. The first parameter is the amount sent/received,
  the latter is the total.

- `bin/main.rs` is updated to implement a terminal progress bar, similar
  to pull request #112 from @moaz-mokhtar.

- Tests updated.

Happy to update if there's a preferred way to handle this, but it works well for me (both in the `bin` example, and my GUI work).