### PR TITLE
Replace pnet dependency with get_if_addrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1.4.3"
 log = "0.4.13"
 zeroize = { version = "1.2.0", features = ["zeroize_derive"] }
 sodiumoxide = "0.2.6"
-pnet = "0.27.2"
+get_if_addrs = "0.5.3"
 byteorder = "1.4.2"
 anyhow = "1.0.38"
 futures = "0.3.12"

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -23,7 +23,6 @@ use async_std::{
 };
 use futures::{future::TryFutureExt, StreamExt};
 use log::*;
-use pnet::{datalink, ipnetwork::IpNetwork};
 use sodiumoxide::crypto::secretbox;
 use std::{net::ToSocketAddrs, str::FromStr, sync::Arc};
 
@@ -152,11 +151,9 @@ pub async fn init(abilities: Vec<Ability>, relay_url: &RelayUrl) -> Result<Trans
     let mut our_hints: Vec<Hint> = Vec::new();
     if abilities.contains(&Ability::DirectTcpV1) {
         our_hints.extend(
-            datalink::interfaces()
+            get_if_addrs::get_if_addrs()?
                 .iter()
-                .filter(|iface| !datalink::NetworkInterface::is_loopback(iface))
-                .flat_map(|iface| iface.ips.iter())
-                .map(|n| n as &IpNetwork)
+                .filter(|iface| !iface.is_loopback())
                 .map(|ip| {
                     Hint::DirectTcpV1(DirectHint {
                         priority: 0.0,


### PR DESCRIPTION
Pnet is tricky to get to compile on Windows, and replacement alternatives are not really hard to find. I chose `get_if_addrs` because it looks like "do one thing and do it well" to me and is cross-platform (the only other cross-platform one is `pnet` itself).

If this turns out to not work in the future, the only alternative I see is to use the `nix` crate on Linux and `ipconfig` on Windows.

Closes #115.