### PR TITLE
Error handling improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,12 @@ log = "0.4.13"
 # zeroize = { version = "1.2.0", features = ["zeroize_derive"] }
 get_if_addrs = "0.5.3"
 byteorder = "1.4.2"
+
 anyhow = "1.0.38"
 derive_more = { version = "0.99.0", default-features = false, features = ["display"] }
+thiserror = "1.0.24"
+eyre = "0.6.5"
+
 futures = "0.3.12"
 async-std = { version = "1.9.0", features = ["attributes", "unstable"] }
 async-tungstenite = { version = "0.13.1", features = ["async-std-runtime"] }
@@ -42,13 +46,14 @@ env_logger = { version = "0.8.2", optional = true }
 console = { version = "0.14.1", optional = true }
 indicatif = { version = "0.16.0", optional = true }
 dialoguer = { version = "0.8.0", optional = true }
+color-eyre = { version = "0.5.7", optional = true }
 
 # for some tests
 [dev-dependencies]
 env_logger = "0.8.2"
 
 [features]
-bin = ["clap", "env_logger", "console", "indicatif", "dialoguer" ]
+bin = ["clap", "env_logger", "console", "indicatif", "dialoguer", "color-eyre" ]
 # TODO remove this one day
 # - Removing it now requires all cargo calls to have --features=bin which is annoying
 # - There is a cargo issue that would allow proper bin dependencies and thus would resolve it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ log = "0.4.13"
 get_if_addrs = "0.5.3"
 byteorder = "1.4.2"
 anyhow = "1.0.38"
+derive_more = { version = "0.99.0", default-features = false, features = ["display"] }
 futures = "0.3.12"
 async-std = { version = "1.9.0", features = ["attributes", "unstable"] }
 async-tungstenite = { version = "0.13.1", features = ["async-std-runtime"] }

--- a/src/core.rs
+++ b/src/core.rs
@@ -22,12 +22,13 @@ use log::*;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum WormholeCoreError {
     /// Some deserialization went wrong, we probably got some garbage
     #[error("Corrupt message received")]
-    ProtocolJson(#[source] serde_json::Error),
+    ProtocolJson(#[from] #[source] serde_json::Error),
     #[error("Corrupt hex string encountered within a message")]
-    ProtocolHex(#[source] hex::FromHexError),
+    ProtocolHex(#[from] #[source] hex::FromHexError),
     /// A generic string message for "something went wrong", i.e.
     /// the server sent some bullshit message order
     #[error("Protocol error: {}", _0)]
@@ -41,7 +42,7 @@ pub enum WormholeCoreError {
     #[error("Cannot decrypt a received message")]
     Crypto,
     #[error("Websocket IO error")]
-    IO(#[source] async_tungstenite::tungstenite::Error),
+    IO(#[from] #[source] async_tungstenite::tungstenite::Error),
 }
 
 impl WormholeCoreError {

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -2,6 +2,7 @@ use crate::{
     core::{
         server_messages::{InboundMessage, OutboundMessage},
         util::random_bytes,
+        WormholeCoreError,
     },
     APIEvent,
 };
@@ -182,11 +183,11 @@ pub struct EncryptedMessage {
 }
 
 impl EncryptedMessage {
-    pub fn decrypt(&self, key: &xsalsa20poly1305::Key) -> anyhow::Result<Vec<u8>> {
+    pub fn decrypt(&self, key: &xsalsa20poly1305::Key) -> Option<Vec<u8>> {
         use super::key;
         let data_key = key::derive_phase_key(&self.side, key, &self.phase);
         key::decrypt_data(&data_key, &self.body)
-            .ok_or_else(|| anyhow::format_err!("Got bad message that could not be decrypted"))
+        // .ok_or_else(|| anyhow::format_err!("Got bad message that could not be decrypted"))
     }
 }
 
@@ -213,7 +214,7 @@ pub enum Event {
      * This might trigger a series of events to release all resources and end up with [`Event::WebsocketClosed`]
      */
     #[display(fmt = "Shutdown({:?})", _0)]
-    ShutDown(anyhow::Result<()>),
+    ShutDown(Result<(), WormholeCoreError>),
 }
 
 // conversion from specific event types to the generic Event

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -92,6 +92,13 @@ impl Deref for TheirSide {
 #[serde(transparent)]
 pub struct EitherSide(pub String);
 
+impl Deref for EitherSide {
+    type Target = String;
+    fn deref(&self) -> &String {
+        &self.0
+    }
+}
+
 impl<S: Into<String>> From<S> for EitherSide {
     fn from(s: S) -> EitherSide {
         EitherSide(s.into())

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -187,7 +187,6 @@ impl EncryptedMessage {
         use super::key;
         let data_key = key::derive_phase_key(&self.side, key, &self.phase);
         key::decrypt_data(&data_key, &self.body)
-        // .ok_or_else(|| anyhow::format_err!("Got bad message that could not be decrypted"))
     }
 }
 

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -10,7 +10,7 @@ use std::{fmt, ops::Deref};
 
 pub use super::wordlist::Wordlist;
 
-#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, derive_more::Display)]
 pub struct AppID(pub String);
 
 impl std::ops::Deref for AppID {
@@ -47,8 +47,9 @@ fn generate_side() -> String {
 }
 
 // MySide is used for the String that we send in all our outbound messages
-#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, derive_more::Display)]
 #[serde(transparent)]
+#[display(fmt = "MySide({})", "&*_0")]
 pub struct MySide(EitherSide);
 
 impl MySide {
@@ -71,8 +72,9 @@ impl Deref for MySide {
 }
 
 // TheirSide is used for the string that arrives inside inbound messages
-#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, derive_more::Display)]
 #[serde(transparent)]
+#[display(fmt = "TheirSide({})", "&*_0")]
 pub struct TheirSide(EitherSide);
 
 impl<S: Into<String>> From<S> for TheirSide {
@@ -88,8 +90,9 @@ impl Deref for TheirSide {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, derive_more::Display)]
 #[serde(transparent)]
+#[display(fmt = "{}", "&*_0")]
 pub struct EitherSide(pub String);
 
 impl Deref for EitherSide {
@@ -105,7 +108,7 @@ impl<S: Into<String>> From<S> for EitherSide {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Hash, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash, Deserialize, Serialize, derive_more::Display)]
 #[serde(transparent)]
 pub struct Phase(pub String);
 
@@ -121,7 +124,7 @@ impl Phase {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, derive_more::Display)]
 #[serde(transparent)]
 pub struct Mailbox(pub String);
 
@@ -165,7 +168,13 @@ impl fmt::Display for Code {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, derive_more::Display)]
+#[display(
+    fmt = "EncryptedMessage {{ side: {}, phase: {}, body: <{} encypted bytes>",
+    side,
+    phase,
+    "body.len()"
+)]
 pub struct EncryptedMessage {
     pub side: TheirSide,
     pub phase: Phase,
@@ -181,23 +190,29 @@ impl EncryptedMessage {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
 pub enum Event {
     /** Got a message from the server */
+    #[display(fmt = "FromIO({})", _0)]
     FromIO(InboundMessage),
+    #[display(fmt = "ToIO({})", _0)]
     ToIO(OutboundMessage),
     /** This is second to the last command issued by the core */
     CloseWebsocket,
     /** This is the last event received by the core. After this the event loop will exit. */
     WebsocketClosed,
     /** Sometimes we queue up messages and then release them */
+    #[display(fmt = "BounceMessage({})", _0)]
     BounceMessage(EncryptedMessage),
+    #[display(fmt = "FromAPI({})", "crate::util::DisplayBytes(_0)")]
     FromAPI(Vec<u8>),
+    #[display(fmt = "ToAPI({})", _0)]
     ToAPI(APIEvent),
     /** Close the connection to the server
      *
      * This might trigger a series of events to release all resources and end up with [`Event::WebsocketClosed`]
      */
+    #[display(fmt = "Shutdown({:?})", _0)]
     ShutDown(anyhow::Result<()>),
 }
 

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -93,9 +93,9 @@ impl KeyMachine {
                 if message.phase.is_pake() {
                     /* Got a pake message, derive key */
                     let key = extract_pake_msg(&message.body)
-                        .map_err(WormholeCoreError::protocol)
+                        .map_err(WormholeCoreError::ProtocolJson)
                         .and_then(|pake_message| {
-                            hex::decode(pake_message).map_err(WormholeCoreError::protocol)
+                            hex::decode(pake_message).map_err(WormholeCoreError::ProtocolHex)
                         })
                         .and_then(|pake_message| {
                             pake_state
@@ -137,10 +137,8 @@ impl KeyMachine {
                         .decrypt(&key)
                         .ok_or(WormholeCoreError::PakeFailed)
                         .and_then(|plaintext| {
-                            String::from_utf8(plaintext).map_err(WormholeCoreError::protocol)
-                        })
-                        .and_then(|version_str| {
-                            serde_json::from_str(&version_str).map_err(WormholeCoreError::protocol)
+                            serde_json::from_slice(&plaintext)
+                                .map_err(WormholeCoreError::ProtocolJson)
                         });
 
                     match versions {

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -25,6 +25,7 @@ enum State {
     S2Unverified(xsalsa20poly1305::Key, Vec<EncryptedMessage>), // key, another message queue
 }
 
+#[derive(Debug)]
 pub(super) struct KeyMachine {
     side: MySide,
     versions: serde_json::Value,
@@ -169,8 +170,14 @@ impl KeyMachine {
                 Mood::Errory
             },
         );
+        let await_nameplate_release = if let Some(nameplate) = self.nameplate {
+            actions.push_back(OutboundMessage::release(nameplate).into());
+            true
+        } else {
+            false
+        };
         super::State::Closing {
-            await_nameplate_release: self.nameplate.is_some(),
+            await_nameplate_release,
             await_mailbox_close: true,
             result,
         }

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -199,6 +199,12 @@ impl KeyMachine {
         actions: &mut VecDeque<Event>,
         result: Result<(), WormholeCoreError>,
     ) -> super::State {
+        let await_nameplate_release = if let Some(nameplate) = self.nameplate {
+            actions.push_back(OutboundMessage::release(nameplate).into());
+            true
+        } else {
+            false
+        };
         self.mailbox_machine.close(
             actions,
             match &result {
@@ -207,12 +213,6 @@ impl KeyMachine {
                 Err(_) => Mood::Errory,
             },
         );
-        let await_nameplate_release = if let Some(nameplate) = self.nameplate {
-            actions.push_back(OutboundMessage::release(nameplate).into());
-            true
-        } else {
-            false
-        };
         super::State::Closing {
             await_nameplate_release,
             await_mailbox_close: true,

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -19,13 +19,29 @@ use super::{
     mailbox, util,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, derive_more::Display)]
 enum State {
+    #[display(
+        fmt = "S1NoPake {{ pake: <censored>, message_queue: <{} items> }}",
+        "_1.len()"
+    )]
     S1NoPake(SPAKE2<Ed25519Group>, Vec<EncryptedMessage>), // pake_state, message queue
+    #[display(
+        fmt = "S2Unverified {{ key: <censored>, message_queue: <{} items> }}",
+        "_1.len()"
+    )]
     S2Unverified(xsalsa20poly1305::Key, Vec<EncryptedMessage>), // key, another message queue
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[display(
+    fmt = "KeyMachine {{ side: {}, versions: {}, nameplate: {:?}, mailbox_machine: {}, state: {} }}",
+    side,
+    versions,
+    nameplate,
+    mailbox_machine,
+    state
+)]
 pub(super) struct KeyMachine {
     side: MySide,
     versions: serde_json::Value,

--- a/src/core/mailbox.rs
+++ b/src/core/mailbox.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::events::{Mailbox, MySide, Phase};
 
+#[derive(Debug)]
 pub struct MailboxMachine {
     mailbox: Mailbox,
     processed: HashSet<Phase>,

--- a/src/core/mailbox.rs
+++ b/src/core/mailbox.rs
@@ -3,7 +3,11 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::events::{Mailbox, MySide, Phase};
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[display(fmt = "MailboxMachine {{ mailbox: {}, side: {}, processed: [{}], pending_outbound: {{ {} }} }} ", mailbox, side, 
+    "processed.iter().map(|p| format!(\"{}\", p)).collect::<Vec<String>>().join(\", \")",
+    "pending_outbound.iter().map(|(phase, message)| format!(\"({}, {})\", phase, crate::util::DisplayBytes(message))).collect::<Vec<String>>().join(\", \")"
+)]
 pub struct MailboxMachine {
     mailbox: Mailbox,
     processed: HashSet<Phase>,

--- a/src/core/running.rs
+++ b/src/core/running.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use std::collections::VecDeque;
 
+#[derive(Debug)]
 pub(super) struct RunningMachine {
     pub phase: u64,
     pub key: xsalsa20poly1305::Key,

--- a/src/core/running.rs
+++ b/src/core/running.rs
@@ -1,8 +1,5 @@
 use super::{key, mailbox};
-use crate::{
-    core::{EncryptedMessage, Event, Mood, MySide, Phase},
-    APIEvent,
-};
+use crate::{core::*, APIEvent};
 use std::collections::VecDeque;
 
 #[derive(Debug, derive_more::Display)]
@@ -52,11 +49,11 @@ impl RunningMachine {
 
         // TODO maybe reorder incoming messages by phase numeral?
         match message.decrypt(&self.key) {
-            Ok(plaintext) => {
+            Some(plaintext) => {
                 actions.push_back(APIEvent::GotMessage(plaintext).into());
             },
-            Err(error) => {
-                actions.push_back(Event::ShutDown(Err(error)));
+            None => {
+                actions.push_back(Event::ShutDown(Err(WormholeCoreError::Crypto)));
             },
         }
 
@@ -66,15 +63,14 @@ impl RunningMachine {
     pub(super) fn shutdown(
         self: Box<Self>,
         actions: &mut VecDeque<Event>,
-        result: anyhow::Result<()>,
+        result: Result<(), WormholeCoreError>,
     ) -> super::State {
-        // TODO handle "scared" mood
         self.mailbox_machine.close(
             actions,
-            if result.is_ok() {
-                Mood::Happy
-            } else {
-                Mood::Errory
+            match &result {
+                Ok(_) => Mood::Happy,
+                Err(e) if e.is_scared() => Mood::Scared,
+                Err(_) => Mood::Errory,
             },
         );
         super::State::Closing {

--- a/src/core/running.rs
+++ b/src/core/running.rs
@@ -5,7 +5,14 @@ use crate::{
 };
 use std::collections::VecDeque;
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[display(
+    fmt = "RunningMachine {{ phase: {}, side: {}, await_nameplate_release: {}, mailbox_machine: {}",
+    phase,
+    side,
+    await_nameplate_release,
+    mailbox_machine
+)]
 pub(super) struct RunningMachine {
     pub phase: u64,
     pub key: xsalsa20poly1305::Key,

--- a/src/core/server_messages.rs
+++ b/src/core/server_messages.rs
@@ -11,19 +11,47 @@ pub struct Nameplate {
 }
 
 // Client sends only these
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, derive_more::Display)]
 #[serde(rename_all = "kebab-case")]
 #[serde(tag = "type")]
 pub enum OutboundMessage {
-    Bind { appid: AppID, side: MySide },
+    #[display(fmt = "Bind {{ appid: {}, side: {} }}", appid, side)]
+    Bind {
+        appid: AppID,
+        side: MySide,
+    },
     List,
     Allocate,
-    Claim { nameplate: String },
-    Release { nameplate: String }, // TODO: nominally optional
-    Open { mailbox: Mailbox },
-    Add { phase: Phase, body: String },
-    Close { mailbox: Mailbox, mood: Mood },
-    Ping { ping: u64 },
+    #[display(fmt = "Claim({})", nameplate)]
+    Claim {
+        nameplate: String,
+    },
+    #[display(fmt = "Release({})", nameplate)]
+    Release {
+        nameplate: String,
+    }, // TODO: nominally optional
+    #[display(fmt = "Open({})", mailbox)]
+    Open {
+        mailbox: Mailbox,
+    },
+    #[display(
+        fmt = "Add {{ phase: {}, body: {} }}",
+        phase,
+        "crate::util::DisplayBytes(body.as_bytes())"
+    )]
+    Add {
+        phase: Phase,
+        body: String,
+    },
+    #[display(fmt = "Close {{ mailbox: {}, mood: {} }}", mailbox, mood)]
+    Close {
+        mailbox: Mailbox,
+        mood: Mood,
+    },
+    #[display(fmt = "Ping({})", ping)]
+    Ping {
+        ping: u64,
+    },
 }
 
 impl OutboundMessage {
@@ -63,23 +91,33 @@ impl OutboundMessage {
 }
 
 // Server sends only these
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, derive_more::Display)]
 #[serde(rename_all = "kebab-case")]
 #[serde(tag = "type")]
 pub enum InboundMessage {
+    #[display(fmt = "Welcome({})", welcome)]
     Welcome {
         welcome: Value, // left mostly-intact for application
     },
+    #[display(fmt = "Nameplates({:?})", nameplates)]
     Nameplates {
         nameplates: Vec<Nameplate>,
     },
+    #[display(fmt = "Allocated({})", nameplate)]
     Allocated {
         nameplate: String,
     },
+    #[display(fmt = "Claimed({})", mailbox)]
     Claimed {
         mailbox: Mailbox,
     },
     Released,
+    #[display(
+        fmt = "Message {{ side: {}, phase: {:?}, body: {} }}",
+        side,
+        phase,
+        "crate::util::DisplayBytes(body.as_bytes())"
+    )]
     Message {
         side: TheirSide,
         phase: String,
@@ -88,9 +126,11 @@ pub enum InboundMessage {
     },
     Closed,
     Ack,
+    #[display(fmt = "Pong({})", pong)]
     Pong {
         pong: u64,
     },
+    #[display(fmt = "Error {{ error: {:?}, .. }}", error)]
     Error {
         error: String,
         orig: Box<InboundMessage>,

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 const MAILBOX_SERVER: &str = "ws://relay.magic-wormhole.io:4000/v1";
 const APPID: &str = "lothar.com/wormhole/rusty-wormhole-test";
+const TIMEOUT: Duration = Duration::from_secs(60);
 
 fn init_logger() {
     /* Ignore errors from succeedent initialization tries */
@@ -125,7 +126,7 @@ pub async fn test_eventloop_exit1() {
         async_std::task::sleep(Duration::from_secs(5)).await;
         log::info!("A Done sleeping.");
     });
-    async_std::future::timeout(Duration::from_secs(5), async {
+    async_std::future::timeout(TIMEOUT, async {
         let (_welcome, connector) = crate::connect_to_server(
             APPID,
             serde_json::json!({}),
@@ -176,7 +177,7 @@ pub async fn test_eventloop_exit2() {
         async_std::task::sleep(Duration::from_secs(5)).await;
         log::info!("A Done sleeping.");
     });
-    async_std::future::timeout(Duration::from_secs(5), async {
+    async_std::future::timeout(TIMEOUT, async {
         let (_welcome, connector) = crate::connect_to_server(
             APPID,
             serde_json::json!({}),
@@ -208,7 +209,7 @@ pub async fn test_eventloop_exit2() {
 pub async fn test_eventloop_exit3() {
     init_logger();
 
-    async_std::future::timeout(Duration::from_secs(5), async {
+    async_std::future::timeout(TIMEOUT, async {
         let mut eventloop_task = None;
         let (_welcome, connector) = crate::connect_to_server(
             APPID,
@@ -390,8 +391,8 @@ pub async fn test_wrong_code() -> eyre::Result<()> {
             eyre::Result::<_>::Ok(())
         })?;
 
-    async_std::future::timeout(Duration::from_secs(5), sender_task).await??;
-    async_std::future::timeout(Duration::from_secs(5), receiver_task).await??;
+    async_std::future::timeout(TIMEOUT, sender_task).await??;
+    async_std::future::timeout(TIMEOUT, receiver_task).await??;
 
     Ok(())
 }

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -42,21 +42,23 @@ pub async fn test_file_rust2rust() -> eyre::Result<()> {
             code_tx.send(welcome.code.0).unwrap();
             let mut w = connector.connect_to_client().await?;
             log::info!("Got key: {}", &w.key);
-            eyre::Result::<_>::Ok(transfer::send_file(
-                &mut w,
-                &magic_wormhole::transit::DEFAULT_RELAY_SERVER
-                    .parse()
-                    .unwrap(),
-                &mut async_std::fs::File::open("examples/example-file.bin").await?,
-                "example-file.bin",
-                std::fs::metadata("examples/example-file.bin")
-                    .unwrap()
-                    .len(),
-                |sent, total| {
-                    log::info!("Sent {} of {} bytes", sent, total);
-                },
+            eyre::Result::<_>::Ok(
+                transfer::send_file(
+                    &mut w,
+                    &magic_wormhole::transit::DEFAULT_RELAY_SERVER
+                        .parse()
+                        .unwrap(),
+                    &mut async_std::fs::File::open("examples/example-file.bin").await?,
+                    "example-file.bin",
+                    std::fs::metadata("examples/example-file.bin")
+                        .unwrap()
+                        .len(),
+                    |sent, total| {
+                        log::info!("Sent {} of {} bytes", sent, total);
+                    },
+                )
+                .await?,
             )
-            .await?)
         })?;
     let receiver_task = async_std::task::Builder::new()
         .name("receiver".to_owned())

--- a/src/core/wordlist.rs
+++ b/src/core/wordlist.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 #[derive(PartialEq)]
 pub struct Wordlist {
-    num_words: usize,
+    pub num_words: usize,
     words: Vec<Vec<String>>,
 }
 

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -153,7 +153,6 @@ impl Hint {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "kebab-case", tag = "type", rename = "direct-tcp-v1")]
 pub struct DirectHint {
     pub priority: f32,
     pub hostname: String,
@@ -161,7 +160,6 @@ pub struct DirectHint {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "kebab-case", tag = "type", rename = "relay-v1")]
 pub struct RelayHint {
     pub hints: Vec<DirectHint>,
 }
@@ -822,6 +820,6 @@ mod test {
             }]),
         ];
         let t = crate::transfer::PeerMessage::new_transit(abilities, hints);
-        assert_eq!(t.serialize(), "{\"transit\":{\"abilities-v1\":[{\"type\":\"direct-tcp-v1\"},{\"type\":\"relay-v1\"}],\"hints-v1\":[{\"hostname\":\"192.168.1.8\",\"port\":46295,\"priority\":0.0,\"type\":\"direct-tcp-v1\"},{\"hints\":[{\"hostname\":\"magic-wormhole-transit.debian.net\",\"port\":4001,\"priority\":2.0,\"type\":\"direct-tcp-v1\"}],\"type\":\"relay-v1\"}]}}")
+        assert_eq!(t.serialize(), "{\"transit\":{\"abilities-v1\":[{\"type\":\"direct-tcp-v1\"},{\"type\":\"relay-v1\"}],\"hints-v1\":[{\"hostname\":\"192.168.1.8\",\"port\":46295,\"priority\":0.0,\"type\":\"direct-tcp-v1\"},{\"hints\":[{\"hostname\":\"magic-wormhole-transit.debian.net\",\"port\":4001,\"priority\":2.0}],\"type\":\"relay-v1\"}]}}")
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,51 @@
 use async_std::{io, io::prelude::*};
 
+/// A warpper around `&[u8]` that implements [`std::fmt::Display`] in a more intelligent+ way.
+pub struct DisplayBytes<'a>(pub &'a [u8]);
+
+impl std::fmt::Display for DisplayBytes<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hex_decode = hex::decode(&self.0);
+        let (string, hex_param) = match hex_decode.as_ref().map(Vec::as_slice) {
+            Ok(decoded_hex) => (decoded_hex, "hex-encoded "),
+            Err(_) => (self.0, ""),
+        };
+
+        let string = match std::str::from_utf8(string) {
+            Ok(string) => string,
+            Err(_) => {
+                return f.write_fmt(format_args!("<{} {}bytes>", string.len(), hex_param));
+            },
+        };
+
+        match string.parse::<serde_json::Value>() {
+            Ok(serde_json::Value::Object(map)) => {
+                return f.write_fmt(format_args!(
+                    "<{}JSON dict with {} key(s)>",
+                    hex_param,
+                    map.len()
+                ));
+            },
+            Ok(serde_json::Value::Array(list)) => {
+                return f.write_fmt(format_args!(
+                    "<{}JSON array with {} entry/ies>",
+                    hex_param,
+                    list.len()
+                ));
+            },
+            _ => (),
+        }
+
+        if string.len() > 20 {
+            f.write_fmt(format_args!("\"{:.15}…\"", string.replace('"', "\\\"")))?;
+        } else {
+            f.write_fmt(format_args!("\"{}\"", string.replace('"', "\\\"")))?;
+        }
+
+        Ok(())
+    }
+}
+
 /**
  * Native reimplementation of [`sodiumoxide::utils::increment_le](https://docs.rs/sodiumoxide/0.2.6/sodiumoxide/utils/fn.increment_le.html).
  * TODO remove after https://github.com/quininer/memsec/issues/11 is resolved.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,21 @@
 use async_std::{io, io::prelude::*};
 
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $err:expr $(,)?) => {
+        if !$cond {
+            return std::result::Result::Err($err.into());
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! bail {
+    ($err:expr $(,)?) => {
+        return std::result::Result::Err($err.into());
+    };
+}
+
 /// A warpper around `&[u8]` that implements [`std::fmt::Display`] in a more intelligent+ way.
 pub struct DisplayBytes<'a>(pub &'a [u8]);
 


### PR DESCRIPTION
- Fixes various bugs related to error handling
- Adds a lot of error handling conditions, including message deserialization failure (Closes #97)
- Moved to custom error types with `thiserror` for the library
- Moved to `eyre` instead of `anyhow` for the binaries
- Also added sane `Display` implementations for a lot of types so the log is a lot more helpful for debugging errors.

This is a good step towards #125, but not all points have been addressed yet.