### PR TITLE
Transit refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures_ringbuf = "0.3.1"
 tar = "0.4.33"
 chrono = "0.4.19"
 
-derive_more = { version = "0.99.0", default-features = false, features = ["display", "deref"] }
+derive_more = { version = "0.99.0", default-features = false, features = ["display", "deref", "from"] }
 thiserror = "1.0.24"
 
 futures = "0.3.12"
@@ -46,6 +46,8 @@ async-tungstenite = { version = "0.14.0", features = ["async-std-runtime", "asyn
 async-io = "1.6.0"
 socket2 = "0.4.1"
 libc = "0.2.101"
+stun_codec = "0.1.13"
+bytecodec = "0.4.15"
 
 # for "bin" feature
 clap = { version = "2.33.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ thiserror = "1.0.24"
 futures = "0.3.12"
 async-std = { version = "1.9.0", features = ["attributes", "unstable"] }
 async-tungstenite = { version = "0.14.0", features = ["async-std-runtime", "async-tls"] }
+async-io = "1.6.0"
+socket2 = "0.4.1"
+libc = "0.2.101"
 
 # for "bin" feature
 clap = { version = "2.33.3", optional = true }

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -53,8 +53,8 @@ impl Key<WormholeKey> {
         let derived_key = self.derive_subkey_from_purpose(&transit_purpose);
         trace!(
             "Input key: {}, Transit key: {}, Transit purpose: '{}'",
-            hex::encode(&**self),
-            hex::encode(&**derived_key),
+            self.to_hex(),
+            derived_key.to_hex(),
             &transit_purpose
         );
         derived_key
@@ -65,6 +65,11 @@ impl<P: KeyPurpose> Key<P> {
     pub fn new(key: Box<secretbox::Key>) -> Self {
         Self(key, std::marker::PhantomData)
     }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(&**self)
+    }
+
     /**
      * Derive a new sub-key from this one
      */

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -47,9 +47,7 @@ pub async fn test_file_rust2rust() -> eyre::Result<()> {
                     std::fs::metadata("examples/example-file.bin")
                         .unwrap()
                         .len(),
-                    |sent, total| {
-                        log::info!("Sent {} of {} bytes", sent, total);
-                    },
+                    |_sent, _total| {},
                 )
                 .await?,
             )
@@ -72,13 +70,7 @@ pub async fn test_file_rust2rust() -> eyre::Result<()> {
             .await?;
 
             let mut buffer = Vec::<u8>::new();
-            req.accept(
-                |received, total| {
-                    log::info!("Received {} of {} bytes", received, total);
-                },
-                &mut buffer,
-            )
-            .await?;
+            req.accept(|_received, _total| {}, &mut buffer).await?;
             Ok(buffer)
         })?;
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -5,7 +5,7 @@
 //! It is bound to an [`APPID`](APPID). Only applications using that APPID (and thus this protocol) can interoperate with
 //! the original Python implementation (and other compliant implementations).
 //!
-//! At its core, [`PeerMessage`s](PeerMessage) are exchanged over an established wormhole connection with the other side.
+//! At its core, "peer messages" are exchanged over an established wormhole connection with the other side.
 //! They are used to set up a [transit] portal and to exchange a file offer/accept. Then, the file is transmitted over the transit relay.
 
 use futures::{AsyncRead, AsyncWrite};
@@ -25,6 +25,9 @@ use log::*;
 use sha2::{digest::FixedOutput, Digest, Sha256};
 use std::path::PathBuf;
 use transit::{TransitConnectError, TransitConnector, TransitError};
+
+mod messages;
+use messages::*;
 
 const APPID_RAW: &str = "lothar.com/wormhole/text-or-file-xfer";
 
@@ -156,105 +159,6 @@ impl TransitAck {
     }
 }
 
-/**
- * The type of message exchanged over the wormhole for this protocol
- */
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum PeerMessage {
-    Offer(OfferType),
-    Answer(AnswerType),
-    /** Tell the other side you got an error */
-    Error(String),
-    /** Used to set up a transit channel */
-    Transit(Arc<transit::TransitType>),
-    #[serde(other)]
-    Unknown,
-}
-
-impl PeerMessage {
-    pub fn new_offer_message(msg: impl Into<String>) -> Self {
-        PeerMessage::Offer(OfferType::Message(msg.into()))
-    }
-
-    pub fn new_offer_file(name: impl Into<PathBuf>, size: u64) -> Self {
-        PeerMessage::Offer(OfferType::File {
-            filename: name.into(),
-            filesize: size,
-        })
-    }
-
-    pub fn new_offer_directory(
-        name: impl Into<PathBuf>,
-        mode: impl Into<String>,
-        compressed_size: u64,
-        numbytes: u64,
-        numfiles: u64,
-    ) -> Self {
-        PeerMessage::Offer(OfferType::Directory {
-            dirname: name.into(),
-            mode: mode.into(),
-            zipsize: compressed_size,
-            numbytes,
-            numfiles,
-        })
-    }
-
-    pub fn new_message_ack(msg: impl Into<String>) -> Self {
-        PeerMessage::Answer(AnswerType::MessageAck(msg.into()))
-    }
-
-    pub fn new_file_ack(msg: impl Into<String>) -> Self {
-        PeerMessage::Answer(AnswerType::FileAck(msg.into()))
-    }
-
-    pub fn new_error_message(msg: impl Into<String>) -> Self {
-        PeerMessage::Error(msg.into())
-    }
-
-    pub fn new_transit(abilities: Vec<transit::Ability>, hints: Vec<transit::Hint>) -> Self {
-        PeerMessage::Transit(Arc::new(transit::TransitType {
-            abilities_v1: abilities,
-            hints_v1: hints,
-        }))
-    }
-
-    #[cfg(test)]
-    pub fn serialize(&self) -> String {
-        json!(self).to_string()
-    }
-
-    pub fn serialize_vec(&self) -> Vec<u8> {
-        serde_json::to_vec(self).unwrap()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub enum OfferType {
-    Message(String),
-    File {
-        filename: PathBuf,
-        filesize: u64,
-    },
-    Directory {
-        dirname: PathBuf,
-        mode: String,
-        zipsize: u64,
-        numbytes: u64,
-        numfiles: u64,
-    },
-    #[serde(other)]
-    Unknown,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum AnswerType {
-    MessageAck(String),
-    FileAck(String),
-}
-
 pub async fn send_file_or_folder<N, M, H>(
     wormhole: &mut Wormhole,
     relay_url: &RelayUrl,
@@ -310,9 +214,15 @@ where
     let connector = transit::init(transit::Ability::all_abilities(), relay_url).await?;
 
     // We want to do some transit
-    debug!("Sending transit message '{:?}", connector.our_side_ttype());
+    debug!("Sending transit message '{:?}", connector.our_hints());
     wormhole
-        .send(PeerMessage::Transit(connector.our_side_ttype().clone()).serialize_vec())
+        .send(
+            PeerMessage::new_transit(
+                connector.our_abilities().to_vec(),
+                (**connector.our_hints()).clone().into(),
+            )
+            .serialize_vec(),
+        )
         .await?;
 
     // Send file offer message.
@@ -322,24 +232,23 @@ where
         .await?;
 
     // Wait for their transit response
-    let other_side_ttype = {
-        let maybe_transit = serde_json::from_slice(&wormhole.receive().await?)?;
-        debug!("received transit message: {:?}", maybe_transit);
-
-        match maybe_transit {
-            PeerMessage::Transit(tmsg) => tmsg,
+    let (their_abilities, their_hints): (Vec<transit::Ability>, transit::Hints) =
+        match serde_json::from_slice(&wormhole.receive().await?)? {
+            PeerMessage::Transit(transit) => {
+                debug!("received transit message: {:?}", transit);
+                (transit.abilities_v1, transit.hints_v1.into())
+            },
             PeerMessage::Error(err) => {
                 bail!(TransferError::PeerError(err));
             },
-            _ => {
-                let error = TransferError::unexpected_message("transit", maybe_transit);
+            other => {
+                let error = TransferError::unexpected_message("transit", other);
                 let _ = wormhole
                     .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
                     .await;
                 bail!(error)
             },
-        }
-    };
+        };
 
     {
         // Wait for file_ack
@@ -363,17 +272,35 @@ where
         }
     }
 
-    let mut transit = connector
+    let mut transit = match connector
         .leader_connect(
             wormhole.key().derive_transit_key(wormhole.appid()),
-            Arc::try_unwrap(other_side_ttype).unwrap(),
+            Arc::new(their_hints),
         )
-        .await?;
+        .await
+    {
+        Ok(transit) => transit,
+        Err(error) => {
+            let error = TransferError::TransitConnect(error);
+            let _ = wormhole
+                .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
+                .await;
+            return Err(error);
+        },
+    };
 
     debug!("Beginning file transfer");
 
     // 11. send the file as encrypted records.
-    let checksum = send_records(&mut transit, file, file_size, progress_handler).await?;
+    let checksum = match send_records(&mut transit, file, file_size, progress_handler).await {
+        Err(TransferError::Transit(error)) => {
+            let _ = wormhole
+                .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
+                .await;
+            Err(TransferError::Transit(error))
+        },
+        other => other,
+    }?;
 
     // 13. wait for the transit ack with sha256 sum from the peer.
     debug!("sent file. Waiting for ack");
@@ -415,9 +342,15 @@ where
     }
 
     // We want to do some transit
-    debug!("Sending transit message '{:?}", connector.our_side_ttype());
+    debug!("Sending transit message '{:?}", connector.our_hints());
     wormhole
-        .send(PeerMessage::Transit(connector.our_side_ttype().clone()).serialize_vec())
+        .send(
+            PeerMessage::new_transit(
+                connector.our_abilities().to_vec(),
+                (**connector.our_hints()).clone().into(),
+            )
+            .serialize_vec(),
+        )
         .await?;
 
     use tar::Builder;
@@ -478,21 +411,23 @@ where
         .await?;
 
     // Wait for their transit response
-    let other_side_ttype = {
-        let maybe_transit = serde_json::from_slice(&wormhole.receive().await?)?;
-        debug!("received transit message: {:?}", maybe_transit);
-
-        match maybe_transit {
-            PeerMessage::Transit(tmsg) => tmsg,
-            _ => {
-                let error = TransferError::unexpected_message("transit", maybe_transit);
+    let (their_abilities, their_hints): (Vec<transit::Ability>, transit::Hints) =
+        match serde_json::from_slice(&wormhole.receive().await?)? {
+            PeerMessage::Transit(transit) => {
+                debug!("received transit message: {:?}", transit);
+                (transit.abilities_v1, transit.hints_v1.into())
+            },
+            PeerMessage::Error(err) => {
+                bail!(TransferError::PeerError(err));
+            },
+            other => {
+                let error = TransferError::unexpected_message("transit", other);
                 let _ = wormhole
                     .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
                     .await;
                 bail!(error)
             },
-        }
-    };
+        };
 
     {
         // Wait for file_ack
@@ -516,12 +451,22 @@ where
         }
     }
 
-    let mut transit = connector
+    let mut transit = match connector
         .leader_connect(
             wormhole.key().derive_transit_key(wormhole.appid()),
-            Arc::try_unwrap(other_side_ttype).unwrap(),
+            Arc::new(their_hints),
         )
-        .await?;
+        .await
+    {
+        Ok(transit) => transit,
+        Err(error) => {
+            let error = TransferError::TransitConnect(error);
+            let _ = wormhole
+                .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
+                .await;
+            return Err(error);
+        },
+    };
 
     debug!("Beginning file transfer");
 
@@ -580,9 +525,15 @@ where
         std::io::Result::Ok(hasher.finalize_fixed())
     });
 
-    let checksum = send_records(&mut transit, &mut reader, length, progress_handler)
-        .await
-        .unwrap();
+    let checksum = match send_records(&mut transit, &mut reader, length, progress_handler).await {
+        Err(TransferError::Transit(error)) => {
+            let _ = wormhole
+                .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
+                .await;
+            Err(TransferError::Transit(error))
+        },
+        other => other,
+    }?;
     /* This should always be ready by now, but just in case */
     let sha256sum = file_sender.await.unwrap();
 
@@ -620,31 +571,35 @@ pub async fn request_file<'a>(
     let connector = transit::init(transit::Ability::all_abilities(), relay_url).await?;
 
     // send the transit message
-    debug!("Sending transit message '{:?}", connector.our_side_ttype());
+    debug!("Sending transit message '{:?}", connector.our_hints());
     wormhole
         .send(
-            crate::transfer::PeerMessage::Transit(connector.our_side_ttype().clone())
-                .serialize_vec(),
+            PeerMessage::new_transit(
+                connector.our_abilities().to_vec(),
+                (**connector.our_hints()).clone().into(),
+            )
+            .serialize_vec(),
         )
         .await?;
 
     // receive transit message
-    let other_side_ttype = match serde_json::from_slice(&wormhole.receive().await?)? {
-        PeerMessage::Transit(transit) => {
-            debug!("received transit message: {:?}", transit);
-            transit
-        },
-        PeerMessage::Error(err) => {
-            bail!(TransferError::PeerError(err));
-        },
-        other => {
-            let error = TransferError::unexpected_message("transit", other);
-            let _ = wormhole
-                .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
-                .await;
-            bail!(error)
-        },
-    };
+    let (their_abilities, their_hints): (Vec<transit::Ability>, transit::Hints) =
+        match serde_json::from_slice(&wormhole.receive().await?)? {
+            PeerMessage::Transit(transit) => {
+                debug!("received transit message: {:?}", transit);
+                (transit.abilities_v1, transit.hints_v1.into())
+            },
+            PeerMessage::Error(err) => {
+                bail!(TransferError::PeerError(err));
+            },
+            other => {
+                let error = TransferError::unexpected_message("transit", other);
+                let _ = wormhole
+                    .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
+                    .await;
+                bail!(error)
+            },
+        };
 
     // 3. receive file offer message from peer
     let maybe_offer = serde_json::from_slice(&wormhole.receive().await?)?;
@@ -680,7 +635,7 @@ pub async fn request_file<'a>(
         filename,
         filesize,
         connector,
-        other_side_ttype,
+        their_hints: Arc::new(their_hints),
     };
 
     Ok(req)
@@ -698,7 +653,7 @@ pub struct ReceiveRequest<'a> {
     /// **Security warning:** this is untrusted and unverified input
     pub filename: PathBuf,
     pub filesize: u64,
-    other_side_ttype: Arc<transit::TransitType>,
+    their_hints: Arc<transit::Hints>,
 }
 
 impl<'a> ReceiveRequest<'a> {
@@ -722,25 +677,46 @@ impl<'a> ReceiveRequest<'a> {
             .send(PeerMessage::new_file_ack("ok").serialize_vec())
             .await?;
 
-        let mut transit = self
+        let mut transit = match self
             .connector
             .follower_connect(
                 self.wormhole
                     .key()
                     .derive_transit_key(self.wormhole.appid()),
-                self.other_side_ttype.clone(),
+                self.their_hints.clone(),
             )
-            .await?;
+            .await
+        {
+            Ok(transit) => transit,
+            Err(error) => {
+                let error = TransferError::TransitConnect(error);
+                let _ = self
+                    .wormhole
+                    .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
+                    .await;
+                return Err(error);
+            },
+        };
 
         debug!("Beginning file transfer");
         // TODO here's the right position for applying the output directory and to check for malicious (relative) file paths
-        tcp_file_receive(
+        match tcp_file_receive(
             &mut transit,
             self.filesize,
             progress_handler,
             content_handler,
         )
         .await
+        {
+            Err(TransferError::Transit(error)) => {
+                let _ = self
+                    .wormhole
+                    .send(PeerMessage::Error(format!("{}", error)).serialize_vec())
+                    .await;
+                Err(TransferError::Transit(error))
+            },
+            other => other,
+        }
     }
 
     /**
@@ -793,7 +769,6 @@ where
         // send the encrypted record
         transit.send_record(&plaintext[0..n]).await?;
         sent_size += n as u64;
-        debug!("sent {} bytes out of {} bytes", sent_size, file_size);
         progress_handler(sent_size, file_size);
 
         // sha256 of the input

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -275,6 +275,7 @@ where
     let mut transit = match connector
         .leader_connect(
             wormhole.key().derive_transit_key(wormhole.appid()),
+            Arc::new(their_abilities),
             Arc::new(their_hints),
         )
         .await
@@ -454,6 +455,7 @@ where
     let mut transit = match connector
         .leader_connect(
             wormhole.key().derive_transit_key(wormhole.appid()),
+            Arc::new(their_abilities),
             Arc::new(their_hints),
         )
         .await
@@ -635,6 +637,7 @@ pub async fn request_file<'a>(
         filename,
         filesize,
         connector,
+        their_abilities: Arc::new(their_abilities),
         their_hints: Arc::new(their_hints),
     };
 
@@ -653,6 +656,7 @@ pub struct ReceiveRequest<'a> {
     /// **Security warning:** this is untrusted and unverified input
     pub filename: PathBuf,
     pub filesize: u64,
+    their_abilities: Arc<Vec<transit::Ability>>,
     their_hints: Arc<transit::Hints>,
 }
 
@@ -683,6 +687,7 @@ impl<'a> ReceiveRequest<'a> {
                 self.wormhole
                     .key()
                     .derive_transit_key(self.wormhole.appid()),
+                self.their_abilities.clone(),
                 self.their_hints.clone(),
             )
             .await

--- a/src/transfer/messages.rs
+++ b/src/transfer/messages.rs
@@ -1,0 +1,207 @@
+//! Over-the-wire messages for the file transfer (including transit)
+//!
+//! The transit protocol does not specify how to deliver the information to
+//! the other side, so it is up to the file transfer to do that.
+
+use crate::transit::{self, Ability, DirectHint};
+use serde_derive::{Deserialize, Serialize};
+#[cfg(test)]
+use serde_json::json;
+use std::path::PathBuf;
+
+/**
+ * The type of message exchanged over the wormhole for this protocol
+ */
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PeerMessage {
+    Offer(OfferType),
+    Answer(AnswerType),
+    /** Tell the other side you got an error */
+    Error(String),
+    /** Used to set up a transit channel */
+    Transit(TransitType),
+    #[serde(other)]
+    Unknown,
+}
+
+impl PeerMessage {
+    pub fn new_offer_message(msg: impl Into<String>) -> Self {
+        PeerMessage::Offer(OfferType::Message(msg.into()))
+    }
+
+    pub fn new_offer_file(name: impl Into<PathBuf>, size: u64) -> Self {
+        PeerMessage::Offer(OfferType::File {
+            filename: name.into(),
+            filesize: size,
+        })
+    }
+
+    pub fn new_offer_directory(
+        name: impl Into<PathBuf>,
+        mode: impl Into<String>,
+        compressed_size: u64,
+        numbytes: u64,
+        numfiles: u64,
+    ) -> Self {
+        PeerMessage::Offer(OfferType::Directory {
+            dirname: name.into(),
+            mode: mode.into(),
+            zipsize: compressed_size,
+            numbytes,
+            numfiles,
+        })
+    }
+
+    pub fn new_message_ack(msg: impl Into<String>) -> Self {
+        PeerMessage::Answer(AnswerType::MessageAck(msg.into()))
+    }
+
+    pub fn new_file_ack(msg: impl Into<String>) -> Self {
+        PeerMessage::Answer(AnswerType::FileAck(msg.into()))
+    }
+
+    pub fn new_error_message(msg: impl Into<String>) -> Self {
+        PeerMessage::Error(msg.into())
+    }
+
+    pub fn new_transit(abilities: Vec<transit::Ability>, hints: Vec<Hint>) -> Self {
+        PeerMessage::Transit(TransitType {
+            abilities_v1: abilities,
+            hints_v1: hints,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn serialize(&self) -> String {
+        json!(self).to_string()
+    }
+
+    pub fn serialize_vec(&self) -> Vec<u8> {
+        serde_json::to_vec(self).unwrap()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OfferType {
+    Message(String),
+    File {
+        filename: PathBuf,
+        filesize: u64,
+    },
+    Directory {
+        dirname: PathBuf,
+        mode: String,
+        zipsize: u64,
+        numbytes: u64,
+        numfiles: u64,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AnswerType {
+    MessageAck(String),
+    FileAck(String),
+}
+
+/**
+ * A set of hints for both sides to find each other
+ */
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct TransitType {
+    pub abilities_v1: Vec<Ability>,
+    pub hints_v1: Vec<Hint>,
+}
+
+impl From<transit::Hints> for Vec<Hint> {
+    fn from(hints: transit::Hints) -> Self {
+        hints
+            .direct_tcp
+            .into_iter()
+            .map(Hint::DirectTcpV1)
+            .chain(std::iter::once(Hint::new_relay(hints.relay)))
+            .collect()
+    }
+}
+
+impl Into<transit::Hints> for Vec<Hint> {
+    fn into(self) -> transit::Hints {
+        let mut direct_tcp = Vec::new();
+        let mut relay = Vec::new();
+
+        /* There is only one "relay hint", though it may contain multiple
+         * items. Yes, this is inconsistent and weird, watch your step.
+         */
+        for hint in self {
+            match hint {
+                Hint::DirectTcpV1(hint) => direct_tcp.push(hint),
+                Hint::DirectUdtV1(_) => unimplemented!(),
+                Hint::RelayV1(RelayHint { hints }) => relay.extend(hints),
+            }
+        }
+
+        transit::Hints { direct_tcp, relay }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case", tag = "type")]
+#[non_exhaustive]
+pub enum Hint {
+    DirectTcpV1(DirectHint),
+    DirectUdtV1(DirectHint),
+    /* Weirdness alarm: a "relay hint" contains multiple "direct hints". This means
+     * that there may be multiple direct hints, but if there are multiple relay hints
+     * it's still only one item because it internally has a list.
+     */
+    RelayV1(RelayHint),
+}
+
+impl Hint {
+    pub fn new_direct_tcp(priority: f32, hostname: &str, port: u16) -> Self {
+        Hint::DirectTcpV1(DirectHint {
+            hostname: hostname.to_string(),
+            port,
+        })
+    }
+
+    pub fn new_direct_udt(priority: f32, hostname: &str, port: u16) -> Self {
+        Hint::DirectUdtV1(DirectHint {
+            hostname: hostname.to_string(),
+            port,
+        })
+    }
+
+    pub fn new_relay(h: Vec<DirectHint>) -> Self {
+        Hint::RelayV1(RelayHint { hints: h })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct RelayHint {
+    pub hints: Vec<DirectHint>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_transit() {
+        let abilities = vec![Ability::DirectTcpV1, Ability::RelayV1];
+        let hints = vec![
+            Hint::new_direct_tcp(0.0, "192.168.1.8", 46295),
+            Hint::new_relay(vec![DirectHint {
+                hostname: "magic-wormhole-transit.debian.net".to_string(),
+                port: 4001,
+            }]),
+        ];
+        let t = crate::transfer::PeerMessage::new_transit(abilities, hints);
+        assert_eq!(t.serialize(), "{\"transit\":{\"abilities-v1\":[{\"type\":\"direct-tcp-v1\"},{\"type\":\"relay-v1\"}],\"hints-v1\":[{\"hostname\":\"192.168.1.8\",\"port\":46295,\"type\":\"direct-tcp-v1\"},{\"hints\":[{\"hostname\":\"magic-wormhole-transit.debian.net\",\"port\":4001}],\"type\":\"relay-v1\"}]}}")
+    }
+}

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -734,7 +734,12 @@ impl Transit {
 
             // 2. read that many bytes into an array (or a vector?)
             let mut buffer = Vec::with_capacity(length);
-            socket.take(length as u64).read_to_end(&mut buffer).await?;
+            let len = socket.take(length as u64).read_to_end(&mut buffer).await?;
+            use std::io::{Error, ErrorKind};
+            ensure!(
+                len == length,
+                Error::new(ErrorKind::UnexpectedEof, "failed to read whole message")
+            );
             buffer
         };
 

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -114,6 +114,7 @@ pub struct TransitType {
  */
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "kebab-case", tag = "type")]
+#[non_exhaustive]
 pub enum Ability {
     /**
      * Try to connect directly to the other side.
@@ -137,6 +138,7 @@ impl Ability {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "kebab-case", tag = "type")]
+#[non_exhaustive]
 pub enum Hint {
     DirectTcpV1(DirectHint),
     RelayV1(RelayHint),
@@ -272,7 +274,7 @@ impl TransitConnector {
     ) -> Result<Transit, TransitConnectError> {
         let transit_key = Arc::new(transit_key);
         /* TODO This Deref thing is getting out of hand. Maybe implementing AsRef or some other trait may help? */
-        debug!("transit key {}", hex::encode(&***transit_key));
+        debug!("transit key {}", transit_key.to_hex());
 
         let port = self.port;
         let listener = self.listener;
@@ -386,7 +388,7 @@ impl TransitConnector {
     ) -> Result<Transit, TransitConnectError> {
         let transit_key = Arc::new(transit_key);
         /* TODO This Deref thing is getting out of hand. Maybe implementing AsRef or some other trait may help? */
-        debug!("transit key {}", hex::encode(&***transit_key));
+        debug!("transit key {}", transit_key.to_hex());
 
         let port = self.port;
         let listener = self.listener;
@@ -637,7 +639,7 @@ fn make_relay_handshake(key: &Key<TransitKey>, tside: &str) -> String {
     let sub_key = key.derive_subkey_from_purpose::<crate::GenericKey>("transit_relay_token");
     format!(
         "please relay {} for side {}\n",
-        hex::encode(&**sub_key),
+        sub_key.to_hex(),
         tside
     )
 }
@@ -677,9 +679,7 @@ async fn follower_handshake_exchange(
             .write_all(
                 format!(
                     "transit receiver {} ready\n\n",
-                    hex::encode(
-                        &**key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver")
-                    )
+                    key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver").to_hex(),
                 )
                 .as_bytes(),
             )
@@ -693,7 +693,7 @@ async fn follower_handshake_exchange(
 
         let expected_tx_handshake = format!(
             "transit sender {} ready\n\ngo\n",
-            hex::encode(&**key.derive_subkey_from_purpose::<crate::GenericKey>("transit_sender"))
+            key.derive_subkey_from_purpose::<crate::GenericKey>("transit_sender").to_hex(),
         );
         ensure!(
             &rx[..] == expected_tx_handshake.as_bytes(),
@@ -739,9 +739,7 @@ async fn leader_handshake_exchange(
             .write_all(
                 format!(
                     "transit sender {} ready\n\n",
-                    hex::encode(
-                        &**key.derive_subkey_from_purpose::<crate::GenericKey>("transit_sender")
-                    )
+                    key.derive_subkey_from_purpose::<crate::GenericKey>("transit_sender").to_hex()
                 )
                 .as_bytes(),
             )
@@ -754,7 +752,7 @@ async fn leader_handshake_exchange(
 
         let expected_rx_handshake = format!(
             "transit receiver {} ready\n\n",
-            hex::encode(&**key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver"))
+            key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver").to_hex()
         );
         ensure!(
             &rx[..] == expected_rx_handshake.as_bytes(),

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -4,7 +4,7 @@
 //! but it depends on some kind of secure communication channel to talk to the other side. Conveniently, Wormhole provides
 //! exactly such a thing :)
 //!
-//! Both clients exchange messages containing hints on how to find each other. These may be local IP Addresses for in case they
+//! Both clients exchange messages containing hints on how to find each other. These may be local IP addresses for in case they
 //! are in the same network, or the URL to a relay server. In case a direct connection fails, both will connect to the relay server
 //! which will transparently glue the connections together.
 //!
@@ -23,7 +23,7 @@ use async_std::{
 #[allow(unused_imports)] /* We need them for the docs */
 use futures::{future::TryFutureExt, Sink, Stream, StreamExt};
 use log::*;
-use std::{net::ToSocketAddrs, str::FromStr, sync::Arc};
+use std::{collections::HashSet, net::ToSocketAddrs, str::FromStr, sync::Arc};
 use xsalsa20poly1305 as secretbox;
 use xsalsa20poly1305::aead::{Aead, NewAead};
 
@@ -98,31 +98,32 @@ pub enum TransitError {
 }
 
 /**
- * A set of hints for both sides to find each other
- */
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-pub struct TransitType {
-    pub abilities_v1: Vec<Ability>,
-    pub hints_v1: Vec<Hint>,
-}
-
-/**
  * Defines a way to find the other side.
  *
- * Each ability comes with a set of [hints](Hint) to encode how to meet up.
+ * Each ability comes with a set of [`Hints`] to encode how to meet up.
  */
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
 #[non_exhaustive]
 pub enum Ability {
     /**
-     * Try to connect directly to the other side.
+     * Try to connect directly to the other side via TCP.
      *
      * This usually requires both participants to be in the same network. [`DirectHint`s](DirectHint) are sent,
      * which encode all local IP addresses for the other side to find us.
      */
     DirectTcpV1,
+    /**
+     * Try to connect directly to the other side via UDT.
+     *
+     * This supersedes [`Ability::DirectTcpV1`] because it has several advantages:
+     *
+     * - Works with stateful firewalls, no need to open up ports
+     * - Works despite many NAT types if combined with STUN
+     * - UDT has a few other interesting performance-related properties that make it better
+     *   suited than TCP (it's literally called "UDP-based Data Transfer Protocol")
+     */
+    DirectUdtV1,
     /** Try to meet the other side at a relay. */
     RelayV1,
     /* TODO Fix once https://github.com/serde-rs/serde/issues/912 is done */
@@ -132,45 +133,48 @@ pub enum Ability {
 
 impl Ability {
     pub fn all_abilities() -> Vec<Ability> {
-        vec![Self::DirectTcpV1, Self::RelayV1]
+        vec![Self::DirectTcpV1, Self::DirectUdtV1, Self::RelayV1]
+    }
+
+    /**
+     * If you absolutely don't want to use any relay servers.
+     *
+     * If the other side forces relay usage or doesn't support any of your connection modes
+     * the attempt will fail.
+     */
+    pub fn force_direct() -> Vec<Ability> {
+        vec![Self::DirectTcpV1, Self::DirectUdtV1]
+    }
+
+    /**
+     * If you don't want to disclose your IP address to your peer
+     *
+     * If the other side forces a the usage of a direct connection the attempt will fail.
+     * Note that the other side might control the relay server being used, if you really
+     * don't want your IP to potentially be disclosed use TOR instead (not supported by
+     * the Rust implementation yet).
+     */
+    pub fn force_relay() -> Vec<Ability> {
+        vec![Self::RelayV1]
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "kebab-case", tag = "type")]
-#[non_exhaustive]
-pub enum Hint {
-    DirectTcpV1(DirectHint),
-    RelayV1(RelayHint),
+#[derive(Clone, Debug, Default)]
+pub struct Hints {
+    pub direct_tcp: Vec<DirectHint>,
+    pub relay: Vec<DirectHint>,
 }
 
-impl Hint {
-    pub fn new_direct(priority: f32, hostname: &str, port: u16) -> Self {
-        Hint::DirectTcpV1(DirectHint {
-            priority,
-            hostname: hostname.to_string(),
-            port,
-        })
-    }
-
-    pub fn new_relay(h: Vec<DirectHint>) -> Self {
-        Hint::RelayV1(RelayHint { hints: h })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct DirectHint {
-    pub priority: f32,
+    // DirectHint also contains a `priority` field, but it is underspecified
+    // and we won't use it
+    // pub priority: f32,
     pub hostname: String,
     pub port: u16,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct RelayHint {
-    pub hints: Vec<DirectHint>,
-}
-
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 enum HostType {
     Direct,
     Relay,
@@ -203,65 +207,67 @@ impl FromStr for RelayUrl {
 /**
  * Initialize a relay handshake
  *
- * Bind a port and generate our [`TransitType`]. This does not do any communication yet.
+ * Bind a port and generate our [`Hints`]. This does not do any communication yet.
  */
 pub async fn init(
     abilities: Vec<Ability>,
     relay_url: &RelayUrl,
 ) -> Result<TransitConnector, std::io::Error> {
-    let listener = TcpListener::bind("[::]:0").await?;
-    let port = listener.local_addr()?.port();
+    let mut our_hints = Hints::default();
+    let mut listener = None;
 
-    let mut our_hints: Vec<Hint> = Vec::new();
+    /* Detect our local IP addresses if the ability is enabled */
     if abilities.contains(&Ability::DirectTcpV1) {
-        our_hints.extend(
+        listener = Some(TcpListener::bind("[::]:0").await?);
+        let port = listener.as_ref().unwrap().local_addr()?.port();
+
+        our_hints.direct_tcp.extend(
             get_if_addrs::get_if_addrs()?
                 .iter()
                 .filter(|iface| !iface.is_loopback())
-                .map(|ip| {
-                    Hint::DirectTcpV1(DirectHint {
-                        priority: 0.0,
-                        hostname: ip.ip().to_string(),
-                        port,
-                    })
+                .map(|ip| DirectHint {
+                    hostname: ip.ip().to_string(),
+                    port,
                 }),
         );
     }
+
     if abilities.contains(&Ability::RelayV1) {
-        our_hints.push(Hint::new_relay(vec![DirectHint {
-            priority: 0.0,
+        our_hints.relay.push(DirectHint {
             hostname: relay_url.host.clone(),
             port: relay_url.port,
-        }]));
+        });
     }
 
     Ok(TransitConnector {
         listener,
-        port,
-        our_side_ttype: Arc::new(TransitType {
-            abilities_v1: abilities,
-            hints_v1: our_hints,
-        }),
+        our_abilities: abilities,
+        our_hints: Arc::new(our_hints),
     })
 }
 
 /**
  * A partially set up [`Transit`] connection.
  *
- * For the transit handshake, each side generates a [ttype](`TransitType`) with all the hints to find the other. You need
- * to exchange it (as in: send yours, receive theirs) with them. This is outside of the transit protocol to be protocol
- * agnostic.
+ * For the transit handshake, each side generates a [`Hints`] with all the information to find the other. You need
+ * to exchange it (as in: send yours, receive theirs) with them. This is outside of the transit protocol, because we
+ * are protocol agnostic.
  */
 pub struct TransitConnector {
-    listener: TcpListener,
-    port: u16,
-    our_side_ttype: Arc<TransitType>,
+    /* Only `Some` if direct-tcp-v1 ability has been enabled. */
+    listener: Option<TcpListener>,
+    our_abilities: Vec<Ability>,
+    our_hints: Arc<Hints>,
 }
 
 impl TransitConnector {
+    pub fn our_abilities(&self) -> &[Ability] {
+        &self.our_abilities
+    }
+
     /** Send this one to the other side */
-    pub fn our_side_ttype(&self) -> &Arc<TransitType> {
-        &self.our_side_ttype
+    pub fn our_hints(&self) -> &Arc<Hints> {
+        &self.our_hints
     }
 
     /**
@@ -270,74 +276,17 @@ impl TransitConnector {
     pub async fn leader_connect(
         self,
         transit_key: Key<TransitKey>,
-        other_side_ttype: TransitType,
+        their_hints: Arc<Hints>,
     ) -> Result<Transit, TransitConnectError> {
+        let Self {
+            listener,
+            our_abilities,
+            our_hints,
+        } = self;
         let transit_key = Arc::new(transit_key);
-        /* TODO This Deref thing is getting out of hand. Maybe implementing AsRef or some other trait may help? */
-        debug!("transit key {}", transit_key.to_hex());
 
-        let port = self.port;
-        let listener = self.listener;
-        // let other_side_ttype = Arc::new(other_side_ttype);
-        // TODO remove this one day
-        let ttype = &*Box::leak(Box::new(other_side_ttype));
-
-        // 8. listen for connections on the port and simultaneously try connecting to the peer port.
-        // extract peer's ip/hostname from 'ttype'
-        let (mut direct_hosts, mut relay_hosts) = get_direct_relay_hosts(ttype);
-
-        let mut hosts: Vec<(HostType, &DirectHint)> = Vec::new();
-        hosts.append(&mut direct_hosts);
-        hosts.append(&mut relay_hosts);
-        // TODO: combine our relay hints with the peer's relay hints.
-
-        let mut handshake_futures = Vec::new();
-        for host in hosts {
-            // TODO use async scopes to borrow instead of cloning one day
-            let transit_key = transit_key.clone();
-            let future = async_std::task::spawn(
-                //async_std::future::timeout(Duration::from_secs(5),
-                async move {
-                    debug!("host: {:?}", host);
-                    let mut direct_host_iter = format!("{}:{}", host.1.hostname, host.1.port)
-                        .to_socket_addrs()
-                        .unwrap();
-                    let direct_host = direct_host_iter.next().unwrap();
-
-                    debug!("peer host: {}", direct_host);
-
-                    TcpStream::connect(direct_host)
-                        .err_into::<TransitHandshakeError>()
-                        .and_then(|socket| leader_handshake_exchange(socket, host.0, &*transit_key))
-                        .await
-                },
-            ); //);
-            handshake_futures.push(future);
-        }
-        handshake_futures.push(async_std::task::spawn(async move {
-            debug!("local host {}", port);
-
-            /* Mixing and matching two different futures library probably isn't the
-             * best idea, but here we are. Simply be careful about prelude::* imports
-             * and don't have both StreamExt/FutureExt/… imported at once
-             */
-            use futures::stream::TryStreamExt;
-            async_std::stream::StreamExt::skip_while(listener.incoming()
-                .err_into::<TransitHandshakeError>()
-                .and_then(move |socket| {
-                    /* Pinning a future + moving some value from outer scope is a bit painful */
-                    let transit_key = transit_key.clone();
-                    Box::pin(async move {
-                        leader_handshake_exchange(socket, HostType::Direct, &*transit_key).await
-                    })
-                }),
-                Result::is_err)
-                /* We only care about the first that succeeds */
-                .next()
-                .await
-                /* Next always returns Some because Incoming is an infinite stream. We gotta succeed _sometime_. */
-                .unwrap()
-        }));
+        let mut handshake_futures =
+            Self::connect(true, transit_key, our_hints, their_hints, listener).await?;
 
         /* Try to get a Transit out of the first handshake that succeeds. If all fail,
          * we fail.
@@ -363,17 +312,19 @@ impl TransitConnector {
         }
         let mut transit = transit;
 
-        /* Cancel all remaining non-finished handshakes */
+        /* Cancel all remaining non-finished handshakes. We could send "nevermind" to explicitly tell
+         * the other side (probably, this is mostly for relay server statistics), but eeh, nevermind :)
+         */
         handshake_futures
             .into_iter()
             .map(async_std::task::JoinHandle::cancel)
             .for_each(std::mem::drop);
 
-        debug!(
-            "Sending 'go' message to {}",
+        transit.socket.write_all(b"go\n").await?;
+        info!(
+            "Established transit connection to '{}'",
             transit.socket.peer_addr().unwrap()
         );
-        transit.socket.write_all(b"go\n").await?;
 
         Ok(transit)
     }
@@ -384,76 +335,17 @@ impl TransitConnector {
     pub async fn follower_connect(
         self,
         transit_key: Key<TransitKey>,
-        other_side_ttype: Arc<TransitType>,
+        their_hints: Arc<Hints>,
     ) -> Result<Transit, TransitConnectError> {
+        let Self {
+            listener,
+            our_abilities,
+            our_hints,
+        } = self;
         let transit_key = Arc::new(transit_key);
-        /* TODO This Deref thing is getting out of hand. Maybe implementing AsRef or some other trait may help? */
-        debug!("transit key {}", transit_key.to_hex());
 
-        let port = self.port;
-        let listener = self.listener;
-        // let other_side_ttype = Arc::new(other_side_ttype);
-        let ttype = &*Box::leak(Box::new(other_side_ttype)); // TODO remove this one day
-
-        // 4. listen for connections on the port and simultaneously try connecting to the
-        //    peer listening port.
-        let (mut direct_hosts, mut relay_hosts) = get_direct_relay_hosts(ttype);
-
-        let mut hosts: Vec<(HostType, &DirectHint)> = Vec::new();
-        hosts.append(&mut direct_hosts);
-        hosts.append(&mut relay_hosts);
-        // TODO: combine our relay hints with the peer's relay hints.
-
-        let mut handshake_futures = Vec::new();
-        for host in hosts {
-            let transit_key = transit_key.clone();
-
-            let future = async_std::task::spawn(
-                //async_std::future::timeout(Duration::from_secs(5),
-                async move {
-                    debug!("host: {:?}", host);
-                    let mut direct_host_iter = format!("{}:{}", host.1.hostname, host.1.port)
-                        .to_socket_addrs()
-                        .unwrap();
-                    let direct_host = direct_host_iter.next().unwrap();
-
-                    debug!("peer host: {}", direct_host);
-
-                    TcpStream::connect(direct_host)
-                        .err_into::<TransitHandshakeError>()
-                        .and_then(|socket| {
-                            follower_handshake_exchange(socket, host.0, &*transit_key)
-                        })
-                        .await
-                },
-            ); //);
-            handshake_futures.push(future);
-        }
-        handshake_futures.push(async_std::task::spawn(async move {
-            debug!("local host {}", port);
-
-            /* Mixing and matching two different futures library probably isn't the
-             * best idea, but here we are. Simply be careful about prelude::* imports
-             * and don't have both StreamExt/FutureExt/… imported at once
-             */
-            use futures::stream::TryStreamExt;
-            async_std::stream::StreamExt::skip_while(listener.incoming()
-                .err_into::<TransitHandshakeError>()
-                .and_then(move |socket| {
-                    /* Pinning a future + moving some value from outer scope is a bit painful */
-                    let transit_key = transit_key.clone();
-                    use futures::future::FutureExt;
-                    async move {
-                        follower_handshake_exchange(socket, HostType::Direct, &*transit_key).await
-                    }.boxed()
-                }),
-                Result::is_err)
-                /* We only care about the first that succeeds */
-                .next()
-                .await
-                /* Next always returns Some because Incoming is an infinite stream. We gotta succeed _sometime_. */
-                .unwrap()
-        }));
+        let mut handshake_futures =
+            Self::connect(false, transit_key, our_hints, their_hints, listener).await?;
 
         /* Try to get a Transit out of the first handshake that succeeds. If all fail,
          * we fail.
@@ -486,6 +378,100 @@ impl TransitConnector {
 
         Ok(transit)
     }
+
+    /** Try to establish a connection with the peer.
+     *
+     * This encapsulates code that is common to both the leader and the follower.
+     */
+    async fn connect(
+        is_leader: bool,
+        transit_key: Arc<Key<TransitKey>>,
+        our_hints: Arc<Hints>,
+        their_hints: Arc<Hints>,
+        listener: Option<TcpListener>,
+    ) -> Result<
+        Vec<async_std::task::JoinHandle<Result<Transit, TransitHandshakeError>>>,
+        TransitConnectError,
+    > {
+        // 8. listen for connections on the port and simultaneously try connecting to the peer port.
+        let tside = Arc::new(hex::encode(rand::random::<[u8; 8]>()));
+        let mut hosts: HashSet<(HostType, DirectHint)> = HashSet::new();
+        hosts.extend(
+            their_hints
+                .direct_tcp
+                .iter()
+                .map(|hint| (HostType::Direct, hint.clone())),
+        );
+        hosts.extend(
+            their_hints
+                .relay
+                .iter()
+                .map(|hint| (HostType::Relay, hint.clone())),
+        );
+        hosts.extend(
+            our_hints
+                .relay
+                .iter()
+                .map(|hint| (HostType::Relay, hint.clone())),
+        );
+
+        let mut handshake_futures = Vec::new();
+        for host in hosts {
+            let transit_key = transit_key.clone();
+            let tside = tside.clone();
+            let future = async_std::task::spawn(
+                //async_std::future::timeout(Duration::from_secs(5),
+                async move {
+                    debug!("host: {:?}", host);
+                    let mut direct_host_iter = format!("{}:{}", host.1.hostname, host.1.port)
+                        .to_socket_addrs()
+                        .unwrap();
+                    let direct_host = direct_host_iter.next().unwrap();
+
+                    debug!("peer host: {}", direct_host);
+
+                    TcpStream::connect(direct_host)
+                        .err_into::<TransitHandshakeError>()
+                        .and_then(|socket| {
+                            handshake_exchange(is_leader, &*tside, socket, host.0, &*transit_key)
+                        })
+                        .await
+                },
+            ); //);
+            handshake_futures.push(future);
+        }
+
+        /* If we allowed the other side to make direct connections to us, we have a listening
+         * socket that will attempt to complete handshakes
+         */
+        if let Some(listener) = listener {
+            handshake_futures.push(async_std::task::spawn(async move {
+                /* Mixing and matching two different futures libraries probably isn't the
+                 * best idea, but here we are. Simply be careful about prelude::* imports
+                 * and don't have both StreamExt/FutureExt/… imported at once
+                 */
+                use futures::stream::TryStreamExt;
+                async_std::stream::StreamExt::skip_while(listener.incoming()
+                    .err_into::<TransitHandshakeError>()
+                    .and_then(move |socket| {
+                        /* Pinning a future + moving some value from outer scope is a bit painful */
+                        let transit_key = transit_key.clone();
+                        let tside = tside.clone();
+                        Box::pin(async move {
+                            handshake_exchange(is_leader, &*tside, socket, HostType::Direct, &*transit_key).await
+                        })
+                    }),
+                    Result::is_err)
+                    /* We only care about the first that succeeds */
+                    .next()
+                    .await
+                    /* Next always returns Some because Incoming is an infinite stream. We gotta succeed _sometime_. */
+                    .unwrap()
+            }));
+        }
+
+        Ok(handshake_futures)
+    }
 }
 
 /**
@@ -496,7 +482,7 @@ impl TransitConnector {
  */
 pub struct Transit {
     /** Raw transit connection */
-    pub socket: TcpStream,
+    socket: TcpStream,
     /** Our key, used for sending */
     pub skey: Key<TransitTxKey>,
     /** Their key, used for receiving */
@@ -630,40 +616,46 @@ impl Transit {
     }
 }
 
-fn generate_transit_side() -> String {
-    let x: [u8; 8] = rand::random();
-    hex::encode(x)
-}
-
 fn make_relay_handshake(key: &Key<TransitKey>, tside: &str) -> String {
     let sub_key = key.derive_subkey_from_purpose::<crate::GenericKey>("transit_relay_token");
-    format!(
-        "please relay {} for side {}\n",
-        sub_key.to_hex(),
-        tside
-    )
+    format!("please relay {} for side {}\n", sub_key.to_hex(), tside)
 }
 
-async fn follower_handshake_exchange(
+/**
+ * Do a transit handshake exchange, to establish a direct connection.
+ *
+ * This automatically does the relay handshake first if necessary. On the follower
+ * side, the future will successfully run to completion if a connection could be
+ * established. On the leader side, the handshake is not 100% completed: the caller
+ * must write `Ok\n` into the stream that should be used (and optionally `Nevermind\n`
+ * into all others).
+ */
+async fn handshake_exchange(
+    is_leader: bool,
+    tside: &str,
     mut socket: TcpStream,
     host_type: HostType,
     key: &Key<TransitKey>,
 ) -> Result<Transit, TransitHandshakeError> {
-    // create record keys
-    /* The order here is correct. The "sender" and "receiver" side are a misnomer and should be called
-     * "leader" and "follower" instead. As a follower, we use the leader key for receiving and our
-     * key for sending.
-     */
-    let rkey = key.derive_subkey_from_purpose("transit_record_sender_key");
-    let skey = key.derive_subkey_from_purpose("transit_record_receiver_key");
-
-    // exchange handshake
-    let tside = generate_transit_side();
+    // 9. create record keys
+    let (rkey, skey) = if is_leader {
+        let rkey = key.derive_subkey_from_purpose("transit_record_receiver_key");
+        let skey = key.derive_subkey_from_purpose("transit_record_sender_key");
+        (rkey, skey)
+    } else {
+        /* The order here is correct. The "sender" and "receiver" side are a misnomer and should be called
+         * "leader" and "follower" instead. As a follower, we use the leader key for receiving and our
+         * key for sending.
+         */
+        let rkey = key.derive_subkey_from_purpose("transit_record_sender_key");
+        let skey = key.derive_subkey_from_purpose("transit_record_receiver_key");
+        (rkey, skey)
+    };
 
     if host_type == HostType::Relay {
         trace!("initiating relay handshake");
         socket
-            .write_all(make_relay_handshake(key, &tside).as_bytes())
+            .write_all(make_relay_handshake(key, tside).as_bytes())
             .await?;
         let mut rx = [0u8; 3];
         socket.read_exact(&mut rx).await?;
@@ -671,15 +663,43 @@ async fn follower_handshake_exchange(
         ensure!(ok_msg == rx, TransitHandshakeError::RelayHandshakeFailed);
     }
 
-    {
+    if is_leader {
+        // for transmit mode, send send_handshake_msg and compare.
+        // the received message with send_handshake_msg
+        socket
+            .write_all(
+                format!(
+                    "transit sender {} ready\n\n",
+                    key.derive_subkey_from_purpose::<crate::GenericKey>("transit_sender")
+                        .to_hex()
+                )
+                .as_bytes(),
+            )
+            .await?;
+
+        // The received message "transit sender $hash ready\n\n" has exactly 89 bytes
+        // TODO do proper line parsing one day, this is atrocious
+        let mut rx: [u8; 89] = [0; 89];
+        socket.read_exact(&mut rx).await?;
+
+        let expected_rx_handshake = format!(
+            "transit receiver {} ready\n\n",
+            key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver")
+                .to_hex()
+        );
+        ensure!(
+            &rx[..] == expected_rx_handshake.as_bytes(),
+            TransitHandshakeError::HandshakeFailed,
+        );
+    } else {
         // for receive mode, send receive_handshake_msg and compare.
         // the received message with send_handshake_msg
-
         socket
             .write_all(
                 format!(
                     "transit receiver {} ready\n\n",
-                    key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver").to_hex(),
+                    key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver")
+                        .to_hex(),
                 )
                 .as_bytes(),
             )
@@ -693,7 +713,8 @@ async fn follower_handshake_exchange(
 
         let expected_tx_handshake = format!(
             "transit sender {} ready\n\ngo\n",
-            key.derive_subkey_from_purpose::<crate::GenericKey>("transit_sender").to_hex(),
+            key.derive_subkey_from_purpose::<crate::GenericKey>("transit_sender")
+                .to_hex(),
         );
         ensure!(
             &rx[..] == expected_tx_handshake.as_bytes(),
@@ -708,120 +729,4 @@ async fn follower_handshake_exchange(
         snonce: Default::default(),
         rnonce: Default::default(),
     })
-}
-
-async fn leader_handshake_exchange(
-    mut socket: TcpStream,
-    host_type: HostType,
-    key: &Key<TransitKey>,
-) -> Result<Transit, TransitHandshakeError> {
-    // 9. create record keys
-    let skey = key.derive_subkey_from_purpose("transit_record_sender_key");
-    let rkey = key.derive_subkey_from_purpose("transit_record_receiver_key");
-
-    // 10. exchange handshake over tcp
-    let tside = generate_transit_side();
-
-    if host_type == HostType::Relay {
-        socket
-            .write_all(make_relay_handshake(key, &tside).as_bytes())
-            .await?;
-        let mut rx = [0u8; 3];
-        socket.read_exact(&mut rx).await?;
-        let ok_msg: [u8; 3] = *b"ok\n";
-        ensure!(ok_msg == rx, TransitHandshakeError::RelayHandshakeFailed);
-    }
-
-    {
-        // for transmit mode, send send_handshake_msg and compare.
-        // the received message with send_handshake_msg
-        socket
-            .write_all(
-                format!(
-                    "transit sender {} ready\n\n",
-                    key.derive_subkey_from_purpose::<crate::GenericKey>("transit_sender").to_hex()
-                )
-                .as_bytes(),
-            )
-            .await?;
-
-        // The received message "transit sender $hash ready\n\n" has exactly 89 bytes
-        // TODO do proper line parsing one day, this is atrocious
-        let mut rx: [u8; 89] = [0; 89];
-        socket.read_exact(&mut rx).await?;
-
-        let expected_rx_handshake = format!(
-            "transit receiver {} ready\n\n",
-            key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver").to_hex()
-        );
-        ensure!(
-            &rx[..] == expected_rx_handshake.as_bytes(),
-            TransitHandshakeError::HandshakeFailed,
-        );
-    }
-
-    Ok(Transit {
-        socket,
-        skey,
-        rkey,
-        snonce: Default::default(),
-        rnonce: Default::default(),
-    })
-}
-
-#[allow(clippy::type_complexity)]
-fn get_direct_relay_hosts<'a, 'b: 'a>(
-    ttype: &'b TransitType,
-) -> (
-    Vec<(HostType, &'a DirectHint)>,
-    Vec<(HostType, &'a DirectHint)>,
-) {
-    let direct_hosts: Vec<(HostType, &DirectHint)> = ttype
-        .hints_v1
-        .iter()
-        .filter_map(|hint| match hint {
-            Hint::DirectTcpV1(dt) => Some((HostType::Direct, dt)),
-            _ => None,
-        })
-        .collect();
-    let relay_hosts_list: Vec<&Vec<DirectHint>> = ttype
-        .hints_v1
-        .iter()
-        .filter_map(|hint| match hint {
-            Hint::RelayV1(rt) => Some(&rt.hints),
-            _ => None,
-        })
-        .collect();
-
-    let _hosts: Vec<(HostType, &DirectHint)> = Vec::new();
-    let maybe_relay_hosts = relay_hosts_list.first();
-    let relay_hosts: Vec<(HostType, &DirectHint)> = match maybe_relay_hosts {
-        Some(relay_host_vec) => relay_host_vec
-            .iter()
-            .map(|host| (HostType::Relay, host))
-            .collect(),
-        None => vec![],
-    };
-
-    (direct_hosts, relay_hosts)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_transit() {
-        let abilities = vec![Ability::DirectTcpV1, Ability::RelayV1];
-        let hints = vec![
-            Hint::new_direct(0.0, "192.168.1.8", 46295),
-            Hint::new_relay(vec![DirectHint {
-                priority: 2.0,
-                hostname: "magic-wormhole-transit.debian.net".to_string(),
-                port: 4001,
-            }]),
-        ];
-        let t = crate::transfer::PeerMessage::new_transit(abilities, hints);
-        assert_eq!(t.serialize(), "{\"transit\":{\"abilities-v1\":[{\"type\":\"direct-tcp-v1\"},{\"type\":\"relay-v1\"}],\"hints-v1\":[{\"hostname\":\"192.168.1.8\",\"port\":46295,\"priority\":0.0,\"type\":\"direct-tcp-v1\"},{\"hints\":[{\"hostname\":\"magic-wormhole-transit.debian.net\",\"port\":4001,\"priority\":2.0}],\"type\":\"relay-v1\"}]}}")
-    }
 }


### PR DESCRIPTION
Fancy things! And code cleanup.

- We now do firewall hole punching. If your device got a firewall connected (and it really should, and by default), direct transfers should now work for you too.
- If you aren't behind any NATs (IPv6 users rejoice), **direct connections should now work across the internet** :tada:
- NAT traversal using STUN, for our poor IPv4 users. Gives you direct connections as well, provided that the NAT behaves well (fortunately, they mostly do).
- If we found a connection over a relay, we wait some longer in the hope of a direct connection.