### PR TITLE
WASM Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1162,6 +1165,7 @@ dependencies = [
  "getrandom 0.2.5",
  "hex",
  "hkdf",
+ "instant",
  "libc",
  "log",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ log = "0.4.13"
 # zeroize = { version = "1.2.0", features = ["zeroize_derive"] }
 base64 = "0.13.0"
 time = { version = "0.3.7", features = ["formatting"] }
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 
 derive_more = { version = "0.99.0", default-features = false, features = ["display", "deref", "from"] }
 thiserror = "1.0.24"

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -980,7 +980,7 @@ impl TransitConnector {
         #[cfg(target_family = "wasm")]
         transit
             .socket
-            .send(ws_stream_wasm::WsMessage::Text("go\n".into()))
+            .send(ws_stream_wasm::WsMessage::Binary("go\n".into()))
             .await?;
 
         #[cfg(not(target_family = "wasm"))]
@@ -1698,7 +1698,7 @@ async fn handshake_exchange(
             .await
             .ok_or(TransitHandshakeError::HandshakeFailed)?;
         let handshake_rx_expected = format!(
-            "transit receiver {} ready\n\n\0",
+            "transit receiver {} ready\n\n",
             key.derive_subkey_from_purpose::<crate::GenericKey>("transit_receiver")
                 .to_hex()
         );

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -907,7 +907,7 @@ impl TransitConnector {
         } = self;
         let transit_key = Arc::new(transit_key);
 
-        let start = std::time::Instant::now();
+        let start = instant::Instant::now();
         let mut connection_stream = Box::pin(
             Self::connect(
                 true,


### PR DESCRIPTION
- Use instant::Instant instead of std::time::Instant for 
- Remove \0 byte after transit 'receiver ready' message
- Change Message type for transit 'go' message from text to binary
- Add error messages for transit protocol debugging