### PR TITLE
Use stable tagged cli-clipboard dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,8 +376,9 @@ dependencies = [
 
 [[package]]
 name = "cli-clipboard"
-version = "0.2.1"
-source = "git+https://github.com/ActuallyAllie/cli-clipboard#c376ba6ce17b71feeed1693f1e5267cf73d7d14b"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae03657ecbc2db46e12b8a1c08a5a58f683057326397bd1aaafad2b70b85c59"
 dependencies = [
  "clipboard-win",
  "objc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,4 +22,4 @@ dialoguer = "0.10.0"
 color-eyre = "0.6.0"
 number_prefix = "0.4.0"
 ctrlc = "3.2.1"
-cli-clipboard = { git = "https://github.com/ActuallyAllie/cli-clipboard" }
+cli-clipboard = "0.3.0"


### PR DESCRIPTION
Upstream finally tagged a release that includes the fixes that were
forcing a Git HEAD usage here. In order for distro packages to be
reproducible it is important to use tagged dependency versions,
especially at tagged release points.

https://github.com/ActuallyAllie/cli-clipboard/issues/13
