### PR TITLE
Send client version with bind message

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -477,26 +477,15 @@ impl<S: Into<String>> From<S> for EitherSide {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, derive_more::Display)]
-#[display(fmt = "{}-{}", "&*_0[0]", "&*_0[1]")]
-pub struct ClientVersion<'a>(#[serde(borrow)] pub [&'a str; 2]);
+#[display(fmt = "{}-{}", "&*_0", "&*_1")]
+pub struct ClientVersion(pub Cow<'static, str>, pub Cow<'static, str>);
 
-impl<'a> ClientVersion<'a> {
-    pub fn new(name: &'a str, version: &'a str) -> Self {
-        let array = [name, version];
-        ClientVersion { 0: array }
-    }
-}
-
-impl<'a> std::ops::Deref for ClientVersion<'a> {
-    type Target = [&'a str; 2];
-    fn deref(&self) -> &[&'a str; 2] {
-        &self.0
-    }
-}
-
-impl<'a> std::ops::DerefMut for ClientVersion<'a> {
-    fn deref_mut(&mut self) -> &mut [&'a str; 2] {
-        &mut self.0
+impl ClientVersion {
+    pub fn new(implementation: Cow<'static, str>, version: Cow<'static, str>) -> Self {
+        ClientVersion {
+            0: implementation,
+            1: version,
+        }
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -476,6 +476,30 @@ impl<S: Into<String>> From<S> for EitherSide {
     }
 }
 
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, derive_more::Display)]
+#[display(fmt = "{}-{}", "&*_0[0]", "&*_0[1]")]
+pub struct ClientVersion<'a>(#[serde(borrow)] pub [&'a str; 2]);
+
+impl<'a> ClientVersion<'a> {
+    pub fn new(name: &'a str, version: &'a str) -> Self {
+        let array = [name, version];
+        ClientVersion { 0: array }
+    }
+}
+
+impl<'a> std::ops::Deref for ClientVersion<'a> {
+    type Target = [&'a str; 2];
+    fn deref(&self) -> &[&'a str; 2] {
+        &self.0
+    }
+}
+
+impl<'a> std::ops::DerefMut for ClientVersion<'a> {
+    fn deref_mut(&mut self) -> &mut [&'a str; 2] {
+        &mut self.0
+    }
+}
+
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Deserialize, Serialize, derive_more::Display)]
 #[serde(transparent)]
 pub struct Phase(pub Cow<'static, str>);

--- a/src/core.rs
+++ b/src/core.rs
@@ -478,13 +478,13 @@ impl<S: Into<String>> From<S> for EitherSide {
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, derive_more::Display)]
 #[display(fmt = "{}-{}", "&*_0", "&*_1")]
-pub struct ClientVersion(pub Cow<'static, str>, pub Cow<'static, str>);
+pub struct ClientVersion(pub String, pub String);
 
 impl ClientVersion {
-    pub fn new(implementation: Cow<'static, str>, version: Cow<'static, str>) -> Self {
+    pub fn new(implementation: &str, version: &str) -> Self {
         ClientVersion {
-            0: implementation,
-            1: version,
+            0: implementation.to_string(),
+            1: version.to_string(),
         }
     }
 }

--- a/src/core/rendezvous.rs
+++ b/src/core/rendezvous.rs
@@ -70,9 +70,9 @@ struct WsConnection {
 }
 
 impl WsConnection {
-    async fn send_message(
+    async fn send_message<'a>(
         &mut self,
-        message: &OutboundMessage,
+        message: &OutboundMessage<'a>,
         queue: Option<&mut MessageQueue>,
     ) -> Result<(), RendezvousError> {
         log::debug!("Sending {}", message);
@@ -322,7 +322,10 @@ impl RendezvousServer {
         &self.side
     }
 
-    async fn send_message(&mut self, message: &OutboundMessage) -> Result<(), RendezvousError> {
+    async fn send_message<'a>(
+        &mut self,
+        message: &OutboundMessage<'a>,
+    ) -> Result<(), RendezvousError> {
         self.connection
             .send_message(message, self.state.as_mut().map(|state| &mut state.queue))
             .await

--- a/src/core/rendezvous.rs
+++ b/src/core/rendezvous.rs
@@ -70,9 +70,9 @@ struct WsConnection {
 }
 
 impl WsConnection {
-    async fn send_message<'a>(
+    async fn send_message(
         &mut self,
-        message: &OutboundMessage<'a>,
+        message: &OutboundMessage,
         queue: Option<&mut MessageQueue>,
     ) -> Result<(), RendezvousError> {
         log::debug!("Sending {}", message);
@@ -322,10 +322,7 @@ impl RendezvousServer {
         &self.side
     }
 
-    async fn send_message<'a>(
-        &mut self,
-        message: &OutboundMessage<'a>,
-    ) -> Result<(), RendezvousError> {
+    async fn send_message(&mut self, message: &OutboundMessage) -> Result<(), RendezvousError> {
         self.connection
             .send_message(message, self.state.as_mut().map(|state| &mut state.queue))
             .await

--- a/src/core/server_messages.rs
+++ b/src/core/server_messages.rs
@@ -1,6 +1,6 @@
 use super::{AppID, ClientVersion, Mailbox, Mood, MySide, Nameplate, Phase, TheirSide};
 use serde_derive::{Deserialize, Serialize};
-use std::{borrow::Cow, collections::HashMap};
+use std::collections::HashMap;
 
 /// Special encoding for the `nameplates` message
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -185,15 +185,10 @@ const CLIENT_NAME: &str = "rust";
 
 impl OutboundMessage {
     pub fn bind(appid: AppID, side: MySide) -> Self {
-        let client_version_string: &str = env!("CARGO_PKG_VERSION");
-        let client_version = ClientVersion::new(
-            Cow::Borrowed(CLIENT_NAME),
-            Cow::Borrowed(client_version_string),
-        );
         OutboundMessage::Bind {
             appid,
             side,
-            client_version,
+            client_version: ClientVersion::new(CLIENT_NAME, env!("CARGO_PKG_VERSION")),
         }
     }
 
@@ -290,7 +285,7 @@ mod test {
 
     #[test]
     fn test_client_version_string_rep() {
-        let client_version = ClientVersion::new(Cow::Borrowed("foo"), Cow::Borrowed("1.0.2"));
+        let client_version = ClientVersion::new("foo", "1.0.2");
 
         assert_eq!(client_version.to_string(), "foo-1.0.2")
     }


### PR DESCRIPTION
This PR sets the `client_version` field in the `bind` message (see [magic-wormhole/magic-wormhole/src/wormhole_rendezvous.py:182](https://github.com/magic-wormhole/magic-wormhole/blob/f372ccc466a4f1a909fae522d54f13f531d529f0/src/wormhole/_rendezvous.py#L182)). So far this is only being used by the Python and Wormhole-William (Go) clients.

It will use the following mapping:

|      |       |
|-----|-----|
| implementation | `rust` |
| version | `<package-version>` |
