### PR TITLE
fix tarpaulin code coverage and add .vscode to gitignore

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -160,6 +160,10 @@ jobs:
         with:
           toolchain: nightly
           override: true
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-tarpaulin
+          version: latest
       - name: Cache ~/.cargo
         uses: actions/cache@v1
         with:
@@ -170,9 +174,11 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-coverage-cargo-build-target
-      - uses: actions-rs/tarpaulin@v0.1
+      - name: Run tarpaulin
+        uses: actions-rs/cargo@v1
         with:
-          args: --all
+          command: tarpaulin
+          args: --workspace --out Xml
       - name: upload coverage
         uses: codecov/codecov-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 **/*.rs.bk
 
 .idea/
+.vscode/


### PR DESCRIPTION
the github action for tarpauling breaks often, and it's not worth depending on it when it's just as easy (and more transparent) to run it using the cargo action

evidence of frequent breakage:
https://github.com/actions-rs/tarpaulin/issues/15
https://github.com/actions-rs/tarpaulin/pull/23