### PR TITLE
Clipboard as an optional feature #157

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,7 +39,7 @@ color-eyre = { workspace = true }
 number_prefix = { workspace = true }
 ctrlc = { workspace = true }
 qr2term = { workspace = true }
-arboard = { workspace = true, features = ["wayland-data-control"] } # Wayland by default, fallback to X11.
+arboard = { optional = true, workspace = true, features = ["wayland-data-control"] } # Wayland by default, fallback to X11.
 tracing = { workspace = true, features = ["log", "log-always"] }
 tracing-subscriber = { workspace=true, features = ["env-filter"] }
 
@@ -47,6 +47,7 @@ tracing-subscriber = { workspace=true, features = ["env-filter"] }
 trycmd = { workspace = true }
 
 [features]
+clipboard = ["dep:arboard"]
 # TLS implementations for websocket connections via async-tungstenite
 # required for optional wss connection to the mailbox server
 tls = ["magic-wormhole/tls"]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -771,7 +771,15 @@ fn server_print_code(
     code: &magic_wormhole::Code,
     _: &Option<url::Url>,
 ) -> eyre::Result<()> {
+    #[cfg(feature = "clipboard")]
+    writeln!(
+        term,
+        "\nThis wormhole's code is: {} (it has been copied to your clipboard)",
+        style(&code).bold()
+    )?;
+    #[cfg(not(feature = "clipboard"))]
     writeln!(term, "\nThis wormhole's code is: {}", style(&code).bold())?;
+    
     writeln!(
         term,
         "On the other side, enter that code into a Magic Wormhole client\n"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -280,7 +280,6 @@ async fn main() -> eyre::Result<()> {
             .init();
     };
 
-
     match app.command {
         WormholeCommand::Send {
             common,
@@ -476,16 +475,8 @@ async fn main() -> eyre::Result<()> {
             tracing::warn!("This is an unstable feature. Make sure that your peer is running the exact same version of the program as you. Also, please report all bugs and crashes.");
             let mut app_config = forwarding::APP_CONFIG;
             app_config.app_version.transit_abilities = parse_transit_args(&common);
-            let (wormhole, _code, relay_hints) = parse_and_connect(
-                &mut term,
-                common,
-                code,
-                None,
-                false,
-                app_config,
-                None,
-            )
-            .await?;
+            let (wormhole, _code, relay_hints) =
+                parse_and_connect(&mut term, common, code, None, false, app_config, None).await?;
 
             let offer = forwarding::connect(
                 wormhole,
@@ -613,7 +604,8 @@ async fn parse_and_connect(
 
             /* Print code and also copy it to clipboard */
             if is_send {
-                #[cfg(feature = "clipboard")] {
+                #[cfg(feature = "clipboard")]
+                {
                     let clipboard = Clipboard::new()
                         .map_err(|err| {
                             tracing::warn!("Failed to initialize clipboard support: {}", err);
@@ -753,12 +745,8 @@ fn sender_print_code(
         style(&code).bold()
     )?;
     #[cfg(not(feature = "clipboard"))]
-    writeln!(
-        term,
-        "\nThis wormhole's code is: {}",
-        style(&code).bold()
-    )?;
-    
+    writeln!(term, "\nThis wormhole's code is: {}", style(&code).bold())?;
+
     writeln!(term, "This is equivalent to the following link: \u{001B}]8;;{}\u{001B}\\{}\u{001B}]8;;\u{001B}\\", &uri, &uri)?;
     let qr =
         qr2term::generate_qr_string(&uri).context("Failed to generate QR code for send link")?;


### PR DESCRIPTION
First pull request in my life so bear with me here! :D
I have added a new feature "clipboard" that when not present disables the `arboard` crate so wormhole can compile on Android and headless machines as requested in #157. I also moved the creation of the clipboard object right before the actual use of it to make it easier to conditionally enable/disable without messing with like 10 function calls. I have also changed the `forward serve` wormhole code message to reflect the clipboard option so the user knows if it got copied. Feedback would be appreciated.