### PR TITLE
qr code generation optional argument

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,6 +89,7 @@ struct CommonLeaderArgs {
     /// Length of code (in bytes/words)
     #[arg(short = 'c', long, value_name = "NUMWORDS", default_value = "2")]
     code_length: usize,
+    /// Generate QR code from send link
     #[arg(long)]
     qr: bool,
 }


### PR DESCRIPTION
The people developing for magic wormhole python seem to want to [implement qr code generation](https://github.com/magic-wormhole/magic-wormhole/pull/555) as an option, ready for their next release. I thought it would make sense to add an argument to optionally suppress qr code generation due to [the minor security risk it poses for always having it on](https://github.com/magic-wormhole/magic-wormhole/pull/546#issuecomment-2414662509). This implementation suppresses it by default without the `--qr` option but if you have a preference for the other way I have [another branch](https://github.com/jherzstein/magic-wormhole.rs/commit/a4dc75765a0d853002631e0212dab1becbe97a0e) I can merge for the `--no-qr` optional implementation. Let me know what you think. Thanks.

For `--help`:
```
$ wormhole-rs send --help
Send a file or a folder

Usage: wormhole-rs send [OPTIONS] <FILENAME|DIRNAME>...

Arguments:
  <FILENAME|DIRNAME>...

Options:
      --relay-server <tcp://HOSTNAME:PORT>
          Use a custom relay server (specify multiple times for multiple relays) [aliases: relay]
      --rendezvous-server <ws://example.org>
          Use a custom rendezvous server. Both sides need to use the same value in order to find each other
      --force-direct
          Disable the relay server support and force a direct connection
      --force-relay
          Always route traffic over a relay server. This hides your IP address from the peer (but not from the server operators. Use Tor for that)
      --code <CODE>
          Enter a code instead of generating one automatically
  -c, --code-length <NUMWORDS>
          Length of code (in bytes/words) [default: 2]
      --qr
          Generate QR code from send link
      --rename <FILE_NAME>
          Suggest a different name to the receiver to keep the file's actual name secret. Not allowed when sending more than one file [aliases: name]
  -v, --verbose
          Enable logging to stdout, for debugging purposes
  -h, --help
          Print help
  -V, --version
          Print version

```
qr code suppressed:
```
$ wormhole-rs send file
This wormhole's code is: 5-recover-scorecard (it has been copied to your clipboard)
This is equivalent to the following link: wormhole-transfer:5-recover-scorecard
QR option not enabled. Skipping QR code generation.
On the other side, open the link or enter that code into a Magic Wormhole client.
For example: wormhole-rs receive 5-recover-scorecard
```
`--qr` added:
```
$ wormhole-rs send --qr file

This wormhole's code is: 3-fascinate-classic (it has been copied to your clipboard)
This is equivalent to the following link: wormhole-transfer:3-fascinate-classic
                                 
   ▄▄▄▄▄   ▄▄ ▄▄ ▄ ▄▄▄   ▄▄▄▄▄   
           ▄▄▄  ▄▄ ▄             
    ▄▄▄    ▄ ▄▄ ▄▄ ▄ ▄▄   ▄▄▄    
  ▄▄▄▄▄▄▄    ▄ ▄▄ ▄ ▄▄  ▄▄▄▄▄▄▄  
    ▄▄ ▄▄▄   ▄  ▄▄  ▄▄▄▄     ▄▄  
  ▄▄   ▄▄    ▄  ▄▄▄ ▄  ▄ ▄   ▄▄  
  ▄▄  ▄▄▄ ▄▄▄  ▄▄▄  ▄   ▄▄▄  ▄▄  
  ▄▄▄ ▄▄▄▄▄ ▄▄  ▄ ▄▄▄▄▄▄▄ ▄▄  ▄  
    ▄▄▄ ▄  ▄▄▄▄ ▄▄▄▄▄▄▄▄▄ ▄▄ ▄   
    ▄▄▄ ▄▄ ▄▄   ▄ ▄ ▄▄ ▄▄▄  ▄ ▄  
  ▄   ▄▄▄  ▄ ▄▄▄▄ ▄▄   ▄▄▄ ▄  ▄  
   ▄▄▄▄▄  ▄▄▄ ▄ ▄▄▄ ▄▄  ▄  ▄     
           ▄ ▄  ▄▄▄▄▄  ▄▄ ▄▄▄▄▄  
    ▄▄▄   ▄ ▄▄  ▄    ▄▄▄▄  ▄     
  ▄▄▄▄▄▄▄ ▄▄▄  ▄   ▄▄▄   ▄  ▄    
                                 

On the other side, open the link or enter that code into a Magic Wormhole client.
For example: wormhole-rs receive 3-fascinate-classic

```