### PR TITLE
cargo: replace macro_rules_attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- dev: Replace the `macro_rules_attribute` test helper to remove the unmaintained `paste` dependency
+
 ## [0.8.0] - 2026-03-26
 
 ### Added
@@ -16,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- dev: Replace the `macro_rules_attribute` test helper to remove the unmaintained `paste` dependency
 - lib: Switched from async-std to smol/async-io
 - lib: Remove explicit entropy feature and make it the default
 - lib: Undeprecate direct access to Transit connections and unify the connection functions. `TransitConnector::connect` is now the only way to set up the connection, and accepts a `TransitRole` enum rather than an `is_leader` boolean. `leader_connect` and `follower_connect` are removed from the API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- dev: Replace the `macro_rules_attribute` test helper to remove the unmaintained `paste` dependency
 - lib: Switched from async-std to smol/async-io
 - lib: Remove explicit entropy feature and make it the default
 - lib: Undeprecate direct access to Transit connections and unify the connection functions. `TransitConnector::connect` is now the only way to set up the connection, and accepts a `TransitRole` enum rather than an `is_leader` boolean. `leader_connect` and `follower_connect` are removed from the API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,20 +1866,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "macro_rules_attribute"
-version = "0.2.2"
+name = "macro_rules_attr"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
-dependencies = [
- "macro_rules_attribute-proc_macro",
- "paste",
-]
-
-[[package]]
-name = "macro_rules_attribute-proc_macro"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+checksum = "ac8e59369155fdc751b1f687fec504eef885545d7f131f4a19741612fc31fdc7"
 
 [[package]]
 name = "magic-wormhole"
@@ -1907,7 +1897,7 @@ dependencies = [
  "hkdf",
  "if-addrs",
  "libc",
- "macro_rules_attribute",
+ "macro_rules_attr",
  "noise-protocol",
  "noise-rust-crypto",
  "percent-encoding",
@@ -2300,12 +2290,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ futures-concurrency = "7.7.1"
 hex = "0.4.2"
 hkdf = "0.12.2"
 indicatif = "0.18"
-macro_rules_attribute = "0.2"
+macro_rules_attr = "0.1"
 noise-protocol = "0.2"
 noise-rust-crypto = "0.6.0-rc.1"
 unit-prefix = "0.5"
@@ -168,7 +168,7 @@ wasmtimer = { workspace = true }
 test-log = { workspace = true, features = ["trace"] }
 eyre = { workspace = true }
 async-process = { workspace = true }
-macro_rules_attribute = { workspace = true }
+macro_rules_attr = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -11,6 +11,7 @@ use crate::{
     self as magic_wormhole, AppConfig, AppID, Code, WormholeError, core::MailboxConnection,
     transit, util::timeout,
 };
+use macro_rules_attr::apply;
 use test_log::test;
 
 macro_rules! test {
@@ -69,7 +70,7 @@ fn default_relay_hints() -> Vec<transit::RelayHint> {
     ]
 }
 
-#[test(macro_rules_attribute::apply(test!))]
+#[apply(test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_connect_with_unknown_code_and_allocate_passes() {
     let code = generate_random_code();
@@ -86,7 +87,7 @@ async fn test_connect_with_unknown_code_and_allocate_passes() {
         .unwrap()
 }
 
-#[test(macro_rules_attribute::apply(test!))]
+#[apply(test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_connect_with_unknown_code_and_no_allocate_fails() {
     tracing::info!("hola!");
@@ -243,7 +244,7 @@ async fn file_offers()
 
 /** Send a file using the Rust implementation. This does not guarantee compatibility with Python! ;) */
 #[cfg(feature = "transfer")]
-#[test(macro_rules_attribute::apply(test!))]
+#[apply(test)]
 // TODO Wasm test disabled, it crashes
 // #[cfg_attr(target_arch = "wasm32", test(wasm_bindgen_test::wasm_bindgen_test))]
 async fn test_file_rust2rust() {
@@ -325,7 +326,7 @@ async fn test_file_rust2rust() {
 /** Test the functionality used by the `send-many` subcommand.
  */
 #[cfg(feature = "transfer")]
-#[test(macro_rules_attribute::apply(test!))]
+#[apply(test)]
 // TODO Wasm test disabled, it crashes
 // #[cfg_attr(target_arch = "wasm32", test(wasm_bindgen_test::wasm_bindgen_test))]
 async fn test_send_many() {
@@ -451,7 +452,7 @@ async fn test_send_many() {
 }
 
 /// Try to send a file, but use a bad code, and see how it's handled
-#[test(macro_rules_attribute::apply(test!))]
+#[apply(test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_wrong_code() {
     let (code_tx, code_rx) = futures::channel::oneshot::channel();
@@ -495,7 +496,7 @@ async fn test_wrong_code() {
 }
 
 /** Connect three people to the party and watch it explode … gracefully */
-#[test(macro_rules_attribute::apply(test!))]
+#[apply(test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_crowded() {
     let initial_mailbox_connection = MailboxConnection::create(APP_CONFIG, 2).await.unwrap();
@@ -518,7 +519,7 @@ async fn test_crowded() {
     }
 }
 
-#[macro_rules_attribute::apply(test!)]
+#[apply(test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 async fn test_connect_with_code_expecting_nameplate() {
     let code = generate_random_code();


### PR DESCRIPTION
The RustSec report for `paste` is still applicable because `macro_rules_attribute` pulls `paste` into the dev-dependency graph. The project only uses `macro_rules_attribute` to apply a local async-test wrapper macro, so this switches those tests to `macro_rules_attr`, which supports the same `#[apply(test)]` use case without depending on `paste`.

Changes:
- Replace the workspace `macro_rules_attribute` dependency with `macro_rules_attr`.
- Update the affected async tests in `src/core/test.rs` from `macro_rules_attribute::apply(test!)` to `#[apply(test)]`.
- Update `Cargo.lock` so `paste` and `macro_rules_attribute` are removed.
- Add a changelog entry under Unreleased.

Validation:
- `cargo metadata --locked --format-version=1 --no-deps`
- `rg -n "paste|macro_rules_attribute" Cargo.lock Cargo.toml src/core/test.rs` returned no matches
- `cargo tree --locked --workspace --all-features --all-targets | rg "macro_rules_attr|macro_rules_attribute|paste"` shows only `macro_rules_attr`
- `cargo fmt --check`
- `cargo check --workspace --all-features --locked`
- `cargo test --workspace --all-features --no-run --locked`
- `git diff --check`

Fixes #340