### PR TITLE
feat(cli): drop redundant 'wormhole send/receive' lines from --help

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -250,9 +250,7 @@ enum WormholeCommand {
     arg_required_else_help = true,
     disable_help_subcommand = true,
     propagate_version = true,
-    after_help = "Run a subcommand with `--help` to know how it's used.\n\
-                 To send files, use `wormhole send <PATH>`.\n\
-                 To receive files, use `wormhole receive <CODE>`."
+    after_help = "Run a subcommand with `--help` to know how it's used."
 )]
 struct WormholeCli {
     /// Enable logging to stdout, for debugging purposes

--- a/cli/tests/cmd/basic.stderr
+++ b/cli/tests/cmd/basic.stderr
@@ -15,5 +15,3 @@ Options:
   -V, --version   Print version
 
 Run a subcommand with `--help` to know how it's used.
-To send files, use `wormhole send <PATH>`.
-To receive files, use `wormhole receive <CODE>`.

--- a/cli/tests/cmd/help.stdout
+++ b/cli/tests/cmd/help.stdout
@@ -15,5 +15,3 @@ Options:
   -V, --version[..]
 
 Run a subcommand with `--help` to know how it's used.
-To send files, use `wormhole send <PATH>`.
-To receive files, use `wormhole receive <CODE>`.


### PR DESCRIPTION
The default binary name is `wormhole-rs`, but the `--help` after-help text references `wormhole send` and `wormhole receive`:

```
Run a subcommand with `--help` to know how it's used.
To send files, use `wormhole send <PATH>`.
To receive files, use `wormhole receive <CODE>`.
```

So the example commands don't match what users actually type. Per @felinira's [comment on #209](https://github.com/magic-wormhole/magic-wormhole.rs/issues/209#issuecomment), the cleanest fix is to drop the last two lines - the per-subcommand `wormhole-rs send --help` / `receive --help` already documents what those subcommands need.

Changes:
- `cli/src/main.rs:253-255`: keep only `Run a subcommand with --help to know how it's used.` in `after_help`.
- `cli/tests/cmd/help.stdout` and `cli/tests/cmd/basic.stderr`: drop the two corresponding lines from the trycmd snapshots.

Verified locally:

```
$ cargo test --test cli_tests
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

All 9 trycmd cases pass.

Closes #209.

This contribution was developed with AI assistance (Claude Code).