### PR TITLE
Make the STUN server configurable (CLI flag + API parameter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - lib: support for encrypted websocket connections through `futures-rustls` as a future replacement for the `async-tls` dependency
+- lib, cli: allow configuring a custom STUN server via `transit::init`'s new `stun_server` parameter, or the CLI's `--stun-server` flag / `WORMHOLE_STUN_SERVER` environment variable
+
+### Changed
+
+- \[lib\]\[breaking\] changed the signature of `transit::init`, `transfer::send`, `transfer::request`, `transfer::request_file`, `transfer::send_file`, `transfer::send_folder`, `transfer::send_file_or_folder`, `forwarding::serve` and `forwarding::connect` to require a new `stun_server: Option<&str>` argument
 
 ## [0.8.1] - 2026-05-07
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -126,6 +126,9 @@ struct CommonArgs {
         env = "WORMHOLE_RELAY_URL",
     )]
     relay_server: Vec<url::Url>,
+    /// Use a custom STUN server for NAT traversal (direct connection discovery).
+    #[arg(long, value_name = "HOSTNAME:PORT", env = "WORMHOLE_STUN_SERVER")]
+    stun_server: Option<String>,
     /// Use a custom rendezvous server. Both sides need to use the same value in order to find each other.
     #[arg(long, value_name = "ws://example.org", value_hint = clap::ValueHint::Url, env = "WORMHOLE_MAILBOX_URL")]
     rendezvous_server: Option<url::Url>,
@@ -330,7 +333,7 @@ async fn async_main() -> eyre::Result<()> {
             let offer = make_send_offer(files, file_name).await?;
 
             let transit_abilities = parse_transit_args(&common);
-            let (wormhole, _code, relay_hints) = match util::cancellable(
+            let (wormhole, _code, relay_hints, stun_server) = match util::cancellable(
                 Box::pin(parse_and_connect(
                     &mut term,
                     common,
@@ -349,7 +352,14 @@ async fn async_main() -> eyre::Result<()> {
                 Err(_) => return Ok(()),
             };
 
-            Box::pin(send(wormhole, relay_hints, offer, transit_abilities)).await?;
+            Box::pin(send(
+                wormhole,
+                relay_hints,
+                stun_server,
+                offer,
+                transit_abilities,
+            ))
+            .await?;
         },
         WormholeCommand::SendMany {
             tries,
@@ -365,7 +375,7 @@ async fn async_main() -> eyre::Result<()> {
             ..
         } => {
             let transit_abilities = parse_transit_args(&common);
-            let (wormhole, code, relay_hints) = {
+            let (wormhole, code, relay_hints, stun_server) = {
                 let connect_fut = Box::pin(parse_and_connect(
                     &mut term,
                     common,
@@ -385,6 +395,7 @@ async fn async_main() -> eyre::Result<()> {
 
             Box::pin(send_many(
                 relay_hints,
+                stun_server,
                 &code,
                 files,
                 file_name,
@@ -404,7 +415,7 @@ async fn async_main() -> eyre::Result<()> {
             ..
         } => {
             let transit_abilities = parse_transit_args(&common);
-            let (wormhole, _code, relay_hints) = {
+            let (wormhole, _code, relay_hints, stun_server) = {
                 let connect_fut = Box::pin(parse_and_connect(
                     &mut term,
                     common,
@@ -424,6 +435,7 @@ async fn async_main() -> eyre::Result<()> {
             Box::pin(receive(
                 wormhole,
                 relay_hints,
+                stun_server,
                 &file_path,
                 noconfirm,
                 transit_abilities,
@@ -496,7 +508,7 @@ async fn async_main() -> eyre::Result<()> {
                     app_config,
                     Some(&server_print_code),
                 ));
-                let (wormhole, _code, relay_hints) =
+                let (wormhole, _code, relay_hints, stun_server) =
                     match futures::future::select(connect_fut, ctrlc_handler()).await {
                         Either::Left((result, _)) => result?,
                         Either::Right(((), _)) => break,
@@ -505,6 +517,7 @@ async fn async_main() -> eyre::Result<()> {
                     wormhole,
                     &transit_handler,
                     relay_hints,
+                    stun_server,
                     targets.clone(),
                     ctrlc_handler(),
                 ))
@@ -525,7 +538,7 @@ async fn async_main() -> eyre::Result<()> {
             );
             let mut app_config = forwarding::APP_CONFIG;
             app_config.app_version.transit_abilities = parse_transit_args(&common);
-            let (wormhole, _code, relay_hints) = parse_and_connect(
+            let (wormhole, _code, relay_hints, stun_server) = parse_and_connect(
                 &mut term, common, code, None, false, false, app_config, None,
             )
             .await?;
@@ -534,6 +547,7 @@ async fn async_main() -> eyre::Result<()> {
                 wormhole,
                 &transit_handler,
                 relay_hints,
+                stun_server,
                 Some(bind_address),
                 &ports,
             )
@@ -612,7 +626,12 @@ async fn parse_and_connect(
     is_send: bool,
     mut app_config: magic_wormhole::AppConfig<impl serde::Serialize + Send + Sync + 'static>,
     print_code: Option<&PrintCodeFn>,
-) -> eyre::Result<(Wormhole, magic_wormhole::Code, Vec<transit::RelayHint>)> {
+) -> eyre::Result<(
+    Wormhole,
+    magic_wormhole::Code,
+    Vec<transit::RelayHint>,
+    Option<String>,
+)> {
     // TODO handle relay servers with multiple endpoints better
     let mut relay_hints: Vec<transit::RelayHint> = common_args
         .relay_server
@@ -627,6 +646,7 @@ async fn parse_and_connect(
                 .unwrap()],
         )?)
     }
+    let stun_server = common_args.stun_server;
 
     if code.is_none() && !is_send {
         code = Some(enter_code()?)
@@ -723,7 +743,7 @@ async fn parse_and_connect(
     print_welcome(term, mailbox_connection.welcome())?;
     let code = mailbox_connection.code().clone();
     let wormhole = Wormhole::connect(mailbox_connection).await?;
-    eyre::Result::<_>::Ok((wormhole, code, relay_hints))
+    eyre::Result::<_>::Ok((wormhole, code, relay_hints, stun_server))
 }
 
 async fn make_send_offer(
@@ -903,6 +923,7 @@ fn server_print_code(
 async fn send(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     offer: transfer::offer::OfferSend,
     transit_abilities: transit::Abilities,
 ) -> eyre::Result<()> {
@@ -911,6 +932,7 @@ async fn send(
     transfer::send(
         wormhole,
         relay_hints,
+        stun_server,
         transit_abilities,
         offer,
         &transit_handler,
@@ -925,6 +947,7 @@ async fn send(
 
 async fn send_many(
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     code: &magic_wormhole::Code,
     files: Vec<PathBuf>,
     file_name: Option<String>,
@@ -948,6 +971,7 @@ async fn send_many(
     /* Special-case the first send with reusing the existing connection */
     send_in_background(
         relay_hints.clone(),
+        stun_server.clone(),
         make_send_offer(files.clone(), file_name.clone()).await?,
         wormhole,
         term.clone(),
@@ -977,6 +1001,7 @@ async fn send_many(
 
         send_in_background(
             relay_hints.clone(),
+            stun_server.clone(),
             make_send_offer(files.clone(), file_name.clone()).await?,
             wormhole,
             term.clone(),
@@ -989,6 +1014,7 @@ async fn send_many(
 
     async fn send_in_background(
         relay_hints: Vec<transit::RelayHint>,
+        stun_server: Option<String>,
         offer: transfer::offer::OfferSend,
         wormhole: Wormhole,
         mut term: Term,
@@ -1005,6 +1031,7 @@ async fn send_many(
                 transfer::send(
                     wormhole,
                     relay_hints,
+                    stun_server,
                     transit_abilities,
                     offer,
                     &transit_handler,
@@ -1035,15 +1062,22 @@ async fn send_many(
 async fn receive(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     target_dir: &std::path::Path,
     noconfirm: bool,
     transit_abilities: transit::Abilities,
 ) -> eyre::Result<()> {
     #[cfg(not(feature = "experimental-transfer-v2"))]
     {
-        let req = transfer::request_file(wormhole, relay_hints, transit_abilities, ctrlc_handler())
-            .await
-            .context("Could not get an offer")?;
+        let req = transfer::request_file(
+            wormhole,
+            relay_hints,
+            stun_server,
+            transit_abilities,
+            ctrlc_handler(),
+        )
+        .await
+        .context("Could not get an offer")?;
         /* If None, the task got cancelled */
         if let Some(req) = req {
             receive_inner_v1(req, target_dir, noconfirm).await
@@ -1053,9 +1087,15 @@ async fn receive(
     }
     #[cfg(feature = "experimental-transfer-v2")]
     {
-        let req = transfer::request(wormhole, relay_hints, transit_abilities, ctrlc_handler())
-            .await
-            .context("Could not get an offer")?;
+        let req = transfer::request(
+            wormhole,
+            relay_hints,
+            stun_server,
+            transit_abilities,
+            ctrlc_handler(),
+        )
+        .await
+        .context("Could not get an offer")?;
 
         match req {
             Some(transfer::ReceiveRequest::V1(req)) => {
@@ -1336,5 +1376,32 @@ mod test {
     #[test]
     fn verify_cli() {
         WormholeCli::command().debug_assert();
+    }
+
+    #[test]
+    fn stun_server_defaults_to_none() {
+        let cli = WormholeCli::parse_from(["wormhole-rs", "send", "some-file"]);
+        let WormholeCommand::Send { common, .. } = cli.command else {
+            panic!("Expected a Send command");
+        };
+        assert_eq!(common.stun_server, None);
+    }
+
+    #[test]
+    fn stun_server_can_be_set_via_cli_flag() {
+        let cli = WormholeCli::parse_from([
+            "wormhole-rs",
+            "send",
+            "--stun-server",
+            "stun.example.org:3478",
+            "some-file",
+        ]);
+        let WormholeCommand::Send { common, .. } = cli.command else {
+            panic!("Expected a Send command");
+        };
+        assert_eq!(
+            common.stun_server,
+            Some("stun.example.org:3478".to_string())
+        );
     }
 }

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -264,6 +264,7 @@ async fn test_file_rust2rust() {
                 transfer::send(
                     wormhole,
                     default_relay_hints(),
+                    None,
                     magic_wormhole::transit::Abilities::ALL,
                     offer,
                     &log_transit_connection,
@@ -289,6 +290,7 @@ async fn test_file_rust2rust() {
             /*let transfer::ReceiveRequest::V1(req) = transfer::request(
                 wormhole,
                 default_relay_hints(),
+                None,
                 magic_wormhole::transit::Abilities::ALL,
                 futures::future::pending(),
             )
@@ -300,6 +302,7 @@ async fn test_file_rust2rust() {
             let req = transfer::request_file(
                 wormhole,
                 default_relay_hints(),
+                None,
                 magic_wormhole::transit::Abilities::ALL,
                 futures::future::pending(),
             )
@@ -359,6 +362,7 @@ async fn test_send_many() {
                     crate::transfer::send(
                         wormhole,
                         default_relay_hints(),
+                        None,
                         magic_wormhole::transit::Abilities::ALL,
                         gen_offer().await?,
                         &log_transit_connection,
@@ -386,6 +390,7 @@ async fn test_send_many() {
                     crate::transfer::send(
                         wormhole,
                         default_relay_hints(),
+                        None,
                         magic_wormhole::transit::Abilities::ALL,
                         gen_offer().await?,
                         &log_transit_connection,
@@ -417,6 +422,7 @@ async fn test_send_many() {
         let req = transfer::request_file(
             wormhole,
             default_relay_hints(),
+            None,
             magic_wormhole::transit::Abilities::ALL,
             futures::future::pending(),
         )

--- a/src/forwarding.rs
+++ b/src/forwarding.rs
@@ -148,6 +148,7 @@ pub async fn serve(
     mut wormhole: Wormhole,
     transit_handler: impl FnOnce(transit::TransitInfo),
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     targets: Vec<(Option<url::Host>, u16)>,
     cancel: impl Future<Output = ()>,
 ) -> Result<(), ForwardingError> {
@@ -165,6 +166,7 @@ pub async fn serve(
         our_version.transit_abilities,
         Some(peer_version.transit_abilities),
         relay_hints,
+        stun_server.as_deref(),
     )
     .await?;
 
@@ -535,6 +537,7 @@ pub async fn connect(
     mut wormhole: Wormhole,
     transit_handler: impl FnOnce(transit::TransitInfo),
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     bind_address: Option<std::net::IpAddr>,
     custom_ports: &[u16],
 ) -> Result<ConnectOffer, ForwardingError> {
@@ -547,6 +550,7 @@ pub async fn connect(
         our_version.transit_abilities,
         Some(peer_version.transit_abilities),
         relay_hints,
+        stun_server.as_deref(),
     )
     .await?;
     let bind_address = bind_address.unwrap_or_else(|| std::net::IpAddr::V6("::".parse().unwrap()));

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -343,6 +343,7 @@ impl PeerMessage {
 pub async fn send(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     transit_abilities: transit::Abilities,
     offer: offer::OfferSend,
     transit_handler: impl FnOnce(transit::TransitInfo),
@@ -357,6 +358,7 @@ pub async fn send(
             return v2::send(
                 wormhole,
                 relay_hints,
+                stun_server,
                 transit_abilities,
                 offer,
                 progress_handler,
@@ -370,6 +372,7 @@ pub async fn send(
     v1::send(
         wormhole,
         relay_hints,
+        stun_server,
         transit_abilities,
         offer,
         progress_handler,
@@ -395,6 +398,7 @@ pub async fn send(
 pub async fn request(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     transit_abilities: transit::Abilities,
     cancel: impl Future<Output = ()>,
 ) -> Result<Option<ReceiveRequest>, TransferError> {
@@ -405,6 +409,7 @@ pub async fn request(
             v2::request(
                 wormhole,
                 relay_hints,
+                stun_server,
                 peer_version,
                 transit_abilities,
                 cancel,
@@ -412,9 +417,15 @@ pub async fn request(
             .await
             .map(|req| req.map(ReceiveRequest::V2))
         } else {
-            v1::request(wormhole, relay_hints, transit_abilities, cancel)
-                .await
-                .map(|req| req.map(ReceiveRequest::V1))
+            v1::request(
+                wormhole,
+                relay_hints,
+                stun_server,
+                transit_abilities,
+                cancel,
+            )
+            .await
+            .map(|req| req.map(ReceiveRequest::V1))
         }
     }
 }
@@ -435,10 +446,18 @@ pub async fn request(
 pub async fn request_file(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     transit_abilities: transit::Abilities,
     cancel: impl Future<Output = ()>,
 ) -> Result<Option<v1::ReceiveRequest>, TransferError> {
-    v1::request(wormhole, relay_hints, transit_abilities, cancel).await
+    v1::request(
+        wormhole,
+        relay_hints,
+        stun_server,
+        transit_abilities,
+        cancel,
+    )
+    .await
 }
 
 /// Send a file to the other side
@@ -454,6 +473,7 @@ pub async fn request_file(
 pub async fn send_file<F, N, G, H>(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     file: &mut F,
     file_name: N,
     file_size: u64,
@@ -471,6 +491,7 @@ where
     v1::send_file(
         wormhole,
         relay_hints,
+        stun_server,
         file,
         file_name,
         file_size,
@@ -494,6 +515,7 @@ where
 pub async fn send_file_or_folder<N, M, G, H>(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     file_path: N,
     file_name: M,
     transit_abilities: transit::Abilities,
@@ -517,6 +539,7 @@ where
         send_folder(
             wormhole,
             relay_hints,
+            stun_server,
             file_path,
             file_name,
             transit_abilities,
@@ -531,6 +554,7 @@ where
         send_file(
             wormhole,
             relay_hints,
+            stun_server,
             &mut file,
             file_name,
             file_size,
@@ -558,6 +582,7 @@ where
 pub async fn send_folder<N, M, G, H>(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     folder_path: N,
     folder_name: M,
     transit_abilities: transit::Abilities,
@@ -576,6 +601,7 @@ where
     v1::send_folder(
         wormhole,
         relay_hints,
+        stun_server,
         folder_name.into(),
         offer,
         transit_abilities,

--- a/src/transfer/v1.rs
+++ b/src/transfer/v1.rs
@@ -72,6 +72,7 @@ impl TransitAck {
 pub(crate) async fn send(
     wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     transit_abilities: transit::Abilities,
     offer: OfferSend,
     progress_handler: impl FnMut(u64, u64) + 'static,
@@ -86,6 +87,7 @@ pub(crate) async fn send(
         send_folder(
             wormhole,
             relay_hints,
+            stun_server,
             "<unnamed folder>".into(),
             folder,
             transit_abilities,
@@ -99,6 +101,7 @@ pub(crate) async fn send(
         send_folder(
             wormhole,
             relay_hints,
+            stun_server,
             folder_name,
             folder,
             transit_abilities,
@@ -121,6 +124,7 @@ pub(crate) async fn send(
         send_file(
             wormhole,
             relay_hints,
+            stun_server,
             &mut file,
             file_name,
             file_size,
@@ -136,6 +140,7 @@ pub(crate) async fn send(
 pub(crate) async fn send_file<F, G, H>(
     mut wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     file: &mut F,
     file_name: impl Into<String>,
     file_size: u64,
@@ -150,7 +155,8 @@ where
     H: FnMut(u64, u64) + 'static,
 {
     let run = Box::pin(async {
-        let connector = transit::init(transit_abilities, None, relay_hints).await?;
+        let connector =
+            transit::init(transit_abilities, None, relay_hints, stun_server.as_deref()).await?;
 
         // We want to do some transit
         tracing::debug!("Sending transit message '{:?}", connector.our_hints());
@@ -236,6 +242,7 @@ where
 pub(crate) async fn send_folder(
     mut wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     mut folder_name: String,
     folder: OfferSendEntry,
     transit_abilities: transit::Abilities,
@@ -244,7 +251,8 @@ pub(crate) async fn send_folder(
     cancel: impl Future<Output = ()>,
 ) -> Result<(), TransferError> {
     let run = Box::pin(async {
-        let connector = transit::init(transit_abilities, None, relay_hints).await?;
+        let connector =
+            transit::init(transit_abilities, None, relay_hints, stun_server.as_deref()).await?;
 
         // We want to do some transit
         tracing::debug!("Sending transit message '{:?}", connector.our_hints());
@@ -408,12 +416,14 @@ pub(crate) async fn send_folder(
 pub async fn request(
     mut wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     transit_abilities: transit::Abilities,
     cancel: impl Future<Output = ()>,
 ) -> Result<Option<ReceiveRequest>, TransferError> {
     // Error handling
     let run = Box::pin(async {
-        let connector = transit::init(transit_abilities, None, relay_hints).await?;
+        let connector =
+            transit::init(transit_abilities, None, relay_hints, stun_server.as_deref()).await?;
 
         // send the transit message
         tracing::debug!("Sending transit message '{:?}", connector.our_hints());

--- a/src/transfer/v2.rs
+++ b/src/transfer/v2.rs
@@ -103,10 +103,17 @@ async fn make_transit(
     wormhole: &mut Wormhole,
     role: TransitRole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<&str>,
     transit_abilities: transit::Abilities,
     peer_abilities: transit::Abilities,
 ) -> Result<(transit::Transit, transit::TransitInfo), TransferError> {
-    let connector = transit::init(transit_abilities, Some(peer_abilities), relay_hints).await?;
+    let connector = transit::init(
+        transit_abilities,
+        Some(peer_abilities),
+        relay_hints,
+        stun_server,
+    )
+    .await?;
 
     /* Send our transit hints */
     wormhole
@@ -155,6 +162,7 @@ async fn make_transit(
 pub async fn send(
     mut wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     transit_abilities: transit::Abilities,
     offer: OfferSend,
     progress_handler: impl FnMut(u64, u64) + 'static,
@@ -172,6 +180,7 @@ pub async fn send(
                 &mut wormhole,
                 TransitRole::Leader,
                 relay_hints,
+                stun_server.as_deref(),
                 transit_abilities,
                 peer_abilities.transit_abilities,
             )
@@ -333,6 +342,7 @@ async fn send_inner(
 pub async fn request(
     mut wormhole: Wormhole,
     relay_hints: Vec<transit::RelayHint>,
+    stun_server: Option<String>,
     peer_version: AppVersion,
     transit_abilities: transit::Abilities,
     cancel: impl Future<Output = ()>,
@@ -348,6 +358,7 @@ pub async fn request(
                 &mut wormhole,
                 TransitRole::Follower,
                 relay_hints,
+                stun_server.as_deref(),
                 transit_abilities,
                 peer_abilities.transit_abilities,
             )

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -39,11 +39,10 @@ use transport::{TransitTransport, TransitTransportRx, TransitTransportTx};
 
 /// ULR to a default hosted relay server. Please don't abuse or DOS.
 pub const DEFAULT_RELAY_SERVER: &str = "tcp://transit.magic-wormhole.io:4001";
-// No need to make public, it's hard-coded anyways (:
-// Open an issue if you want an API for this
-// Use <stun.stunprotocol.org:3478> for non-production testing
+/// Default STUN server used to discover our own public IP address. Please don't abuse or DOS.
+/// For non-production testing, consider using `stun.stunprotocol.org:3478` instead.
 #[cfg(not(target_family = "wasm"))]
-const PUBLIC_STUN_SERVER: &str = "stun.piegames.de:3478";
+pub const DEFAULT_STUN_SERVER: &str = "stun.piegames.de:3478";
 
 /// Marker type for base key used in the Transit protocol.
 #[derive(Debug)]
@@ -725,15 +724,24 @@ impl std::fmt::Display for TransitInfo {
  * Initialize a relay handshake
  *
  * Bind a port and generate our [`Hints`]. This does not do any communication yet.
+ *
+ * `stun_server` optionally overrides the STUN server used to discover our own public IP
+ * address. If `None`, the default STUN server (`DEFAULT_STUN_SERVER`) is used. The expected
+ * format is `"HOSTNAME:PORT"`. If the hostname cannot be resolved, we fall back to not using
+ * STUN at all (i.e. no direct connection hints based on our public IP will be generated).
  */
 pub async fn init(
     mut abilities: Abilities,
     peer_abilities: Option<Abilities>,
     relay_hints: Vec<RelayHint>,
+    /* Only used on non-wasm targets, where we can actually do STUN queries and open sockets. */
+    #[allow(unused_variables)] stun_server: Option<&str>,
 ) -> Result<TransitConnector, std::io::Error> {
     let mut our_hints = Hints::default();
     #[cfg(not(target_family = "wasm"))]
     let mut sockets = None;
+    #[cfg(not(target_family = "wasm"))]
+    let stun_server = stun_server.unwrap_or(DEFAULT_STUN_SERVER);
 
     if let Some(peer_abilities) = peer_abilities {
         abilities = abilities.intersect(&peer_abilities);
@@ -750,7 +758,7 @@ pub async fn init(
 
             let socket: MaybeConnectedSocket = match crate::util::timeout(
                 std::time::Duration::from_secs(4),
-                transport::tcp_get_external_ip(),
+                transport::tcp_get_external_ip(stun_server),
             )
             .await
             .map_err(|_| StunError::Timeout)

--- a/src/transit/transport.rs
+++ b/src/transit/transport.rs
@@ -100,10 +100,12 @@ pub(super) fn set_socket_opts(socket: &socket2::Socket) -> std::io::Result<()> {
 
 /** Perform a STUN query to get the external IP address */
 #[cfg(not(target_family = "wasm"))]
-pub(super) async fn tcp_get_external_ip() -> Result<(SocketAddr, TcpStream), StunError> {
+pub(super) async fn tcp_get_external_ip(
+    stun_server: &str,
+) -> Result<(SocketAddr, TcpStream), StunError> {
     let mut socket = tcp_connect_custom(
         &"[::]:0".parse::<SocketAddr>().unwrap().into(),
-        &super::PUBLIC_STUN_SERVER
+        &stun_server
             .to_socket_addrs()?
             /* If you find yourself behind a NAT66, open an issue */
             .find(|x| x.is_ipv4())


### PR DESCRIPTION
Closes #377

## What & why

Adds a `stun_server` parameter threaded from the CLI down to `transit::init()`, mirroring the existing relay-server pattern:

- `--stun-server <HOSTNAME:PORT>` CLI flag + `WORMHOLE_STUN_SERVER` env var (symmetric with `--relay-server` / `WORMHOLE_RELAY_URL`)
- `PUBLIC_STUN_SERVER` renamed to `pub const DEFAULT_STUN_SERVER` (symmetric with `DEFAULT_RELAY_SERVER`)
- `transit::init()` takes `stun_server: Option<&str>`, falling back to `DEFAULT_STUN_SERVER` when `None`; public `transfer`/`forwarding` entry points take `Option<String>` (owned, since the CLI spawns them as `'static` tasks) and pass it down via `.as_deref()`

The default (`stun.piegames.de:3478`) is **unchanged** — per @felinira's comment on the issue, picking an alternative server is a separate concern; this PR just makes it configurable so users can switch without a fork.

If the configured value fails to resolve, behavior matches the existing STUN failure path: a warning is logged and the connection falls back to a plain socket.

## Breaking change

Nine public library functions (`transit::init`, `transfer::{send,request,request_file,send_file,send_folder,send_file_or_folder}`, `forwarding::{serve,connect}`) gain a required `stun_server` argument. Recorded in the CHANGELOG under `### Changed` with the `[lib][breaking]` convention.

## How to test

- `wormhole-rs send --help` shows `--stun-server <HOSTNAME:PORT>` and `[env: WORMHOLE_STUN_SERVER=]`
- `cargo test --workspace --features all,native-tls,experimental` — all green (includes 2 new clap parsing tests for the flag/default)
- Ran the same checks as CI locally: `cargo fmt --check`, `cargo clippy --all-features`, per-feature builds (`transit`/`transfer`/`forwarding`/no-default), `magic-wormhole-cli --features=all`, and `wasm32-unknown-unknown` builds — all passing

## Notes

This PR was implemented with LLM assistance; all changes were human-reviewed and every check above was run locally before submission.
